### PR TITLE
Removes link to last year's sponsor registration form

### DIFF
--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -66,7 +66,7 @@ published: true
 
                 {% if site.data.conf.sponsor-contact-email != "" %}
                 <p>
-                    If you're ready to make a pledge, please <a href="{{site.data.conf.sponsor-btn-link}}">visit our sponsor registration form</a>. If you have questions, please get in touch with <a href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
+                    If you're ready to make a pledge, please please get in touch with <a href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
                 </p>
                 {% endif %}
 


### PR DESCRIPTION
This link was for the form from last year, this year's isn't ready yet. Just use the email for now.