### PR TITLE
Replaces 2021 with {{site.data.conf.year}} in Sponsorship Descriptions

### DIFF
--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -241,7 +241,7 @@ published: true
 
                     <p><strong><span class="text-danger">5 available</span> at $1,500 (one per day)</strong></p>
                     <p>
-                        Each day of Code4Lib 2021 will be shared on the Code4Lib YouTube Channel. Before the videos are posted, they will be captioned and edited, and a closing screen with a Thank You to the day's Sponsor will be added to the end of each video. Sponsor benefits include:
+                        Each day of Code4Lib {{site.data.conf.year}} will be shared on the Code4Lib YouTube Channel. Before the videos are posted, they will be captioned and edited, and a closing screen with a Thank You to the day's Sponsor will be added to the end of each video. Sponsor benefits include:
                     <ul>
                         <li>Acknowledgement on Published Video</li>
                         <li>Small logo on the conference website as Video Sponsor</li>


### PR DESCRIPTION
This PR replaces `2021` with `{{site.data.conf.year}}` in sponsorship descriptions. This ensures that the upcoming conference year from our main `conf.yml` file gets populated in each opportunity on the prospectus page.

Closes #11 