### PR TITLE
Enable talk-proposals

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -188,7 +188,7 @@ workshop-proposals:
 talk-proposals:
   show: true
   submission-form: 'https://docs.google.com/forms/d/e/1FAIpQLSc3WHM4INwlzBmpRXwJQTKls0yIr0Vafk2EVhfu5H_o0-aAgw/viewform'
-  end-date: '2021-11-17'
+  end-date: '2021-11-19'
 
 panel-proposals:
   show: false


### PR DESCRIPTION
This PR closes issue #14

This branch should display the 'Propose a talk' button on the conference homepage:

<img width="1186" alt="Screen Shot 2021-10-25 at 3 27 16 PM" src="https://user-images.githubusercontent.com/10561752/138758280-ebf815ad-6def-41d3-a6c2-7bd2e090c021.png">

**To test:**
- confirm the talk proposal button takes you to this year's talk proposal form
- review the information in the 'About talk proposals' link for accuracy