### PR TITLE
open keynote proposals

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -177,9 +177,9 @@ sponsorpage-sponsor-button: false
 ###########
 
 keynote-proposals:
-  show: false
+  show: true
   submission-form: 'https://wiki.code4lib.org/2022_Keynote_Speakers_Nominations'
-  end-date: '2021-11-25'
+  end-date: '2021-11-18'
 
 workshop-proposals:
   show: true


### PR DESCRIPTION
This PR enables the display of the 'Propose a Speaker' button on the conference homepage.

![Screen Shot 2021-10-28 at 11 31 54 AM](https://user-images.githubusercontent.com/10561752/139288359-f61f893d-e64c-414b-82ab-41a123e5f7b7.png)

**To test:** Pull down this branch, build the site, confirm the button displays and properly links to the 2022 wiki page for keynote proposals. 

Closes #24 


