### PR TITLE
close pre-conference proposals, closes #21

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -182,7 +182,7 @@ keynote-proposals:
   end-date: '2021-11-18'
 
 workshop-proposals:
-  show: true
+  show: false
   submission-form: 'https://docs.google.com/forms/d/e/1FAIpQLSfh1ri7kmxtZv5SdfKJ-Q6EoiTFYVxtaFNhbh2Wzpzxcr0BcQ/viewform'
   end-date: '2021-11-18'
 


### PR DESCRIPTION
Scheduled to merge on Nov 28 at midnight Pacific time, per extended deadline.

> The standard conference registration fee will apply. Proposals can be submitted through Sunday, November 28, 2021, at 11:59pm Pacific time. Voting will start Tuesday, November 30, 2021, and continue through Friday, December 17, 2021, at 11:59pm Pacific time. The committee plans to announce selected proposals by Friday, February 4, 2022.

To test:

1.  merge PR
2. visit home page, no "Conference Workshops" section appears
3. visit schedule /schedule/timeline, no "Conference Workshops" section appears

/schedule 2021-11-28T23:59-08:00