### PR TITLE
update prospectus info for 2022

### DIFF
--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -111,12 +111,12 @@ published: true
                     <p>Benefits include:</p>
                     <ul>
                       <li>Acknowledgement during opening and closing sessions</li>
-                      <li>Large logo or name on conference website as Platinum Sponsor</li>
-                      <li>Large logo or name on Conference "Screensaver" as displayed throughout conference</li>
+                      <li>Large logo on conference website as Platinum Sponsor</li>
+                      <li>Large logo on Conference "Screensaver" (to be displayed throughout conference)</li>
                       <li>Large logo on conference T-shirt (b&amp;w vector image required)</li>
-                      <li>$1,000 contribution to the Financial Assistance Fund</li>
-                      <li>Exhibitor Booth (details dependent on Conference Platform)</li>
-                      <li>Sponsorship Banner / Recognition on Conference Platform</li>
+                      <li>$1,000 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Exhibitor Table</li>
+                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
                       <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
                       <li>2 free conference registrations</li>
                     </ul>
@@ -133,11 +133,11 @@ published: true
                     <ul>
                       <li>Acknowledgement during opening and closing sessions</li>
                       <li>Medium logo on the conference website as Gold Sponsor</li>
-                      <li>Medium logo on Conference "Screensaver" as displayed throughout conference</li>
+                      <li>Medium logo on Conference "Screensaver" (to be displayed throughout conference)</li>
                       <li>Medium logo on conference T-shirt (b&amp;w vector image required)</li>
-                      <li>$500 contribution to the Financial Assistance Fund</li>
-                      <li>Exhibitor Booth (details dependent on Conference Platform)</li>
-                      <li>Sponsorship Banner / Recognition on Conference Platform</li>
+                      <li>$500 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Exhibitor Table</li>
+                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
                       <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
                       <li>1 free conference registration</li>
                     </ul>
@@ -157,11 +157,10 @@ published: true
                     <ul>
                       <li>Acknowledgement during opening and closing sessions</li>
                       <li>Small logo on the conference website as Silver Sponsor</li>
-                      <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>
+                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                       <li>Small logo on Conference T-shirt (b&amp;w vector image required)</li>
-                      <li>$250 contribution to the Financial Assistance Fund</li>
-                      <li>Exhibitor Booth (details dependent on Conference Platform)</li>
-                      <li>Sponsorship Banner / Recognition on Conference Platform</li>
+                      <li>$250 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
                     </ul>
                 </div>
             </div>
@@ -176,10 +175,9 @@ published: true
                     <ul>
                       <li>Acknowledgement during opening and closing sessions</li>
                       <li>Small logo on the conference website as Bronze Sponsor</li>
-                      <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>
+                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                       <li>Name on conference T-shirt</li>
-                      <li>$100 contribution to the Financial Assistance Fund</li>
-                      <li>Exhibitor Booth (details dependent on Conference Platform)</li>
+                      <li>$100 contribution to the Diversity, Accessibility and Inclusion Fund</li>
                     </ul>
                 </div>
             </div>
@@ -194,7 +192,7 @@ published: true
                     <ul>
                       <li>Acknowledgement during opening and closing sessions</li>
                       <li>Small logo on the conference website as Contributor Sponsor</li>
-                      <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>
+                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                     </ul>
                 </div>
             </div>
@@ -211,7 +209,7 @@ published: true
                     <p><strong>$300 - $749</strong></p>
                     <ul>
                         <li>Small logo on the conference website as Supporter Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                     </ul>
                 </div>
             </div>
@@ -225,19 +223,40 @@ published: true
             </div>
 
             <div class="col-12">
+                <p>Code4Lib seeks to provide a welcoming, inclusive, professionally engaging, fun, and safe conference (and ongoing community) experience for everyone. To accomplish this, we are re-focusing our previously named “Targeted Sponsors” on Diversity, Accessibility and Inclusion. Each of the sponsorship opportunities listed below, are aimed at providing an inclusive experience for all of our attendees.</p>
+            </div>
+
+
+            <div class="col-12">
+                <div class="thumbnail">
+                    <a name="Streaming"></a>
+                    <h3>Streaming Video Sponsor</h3>
+                    <p><strong><span class="text-danger">2 available</span> at $2,500</strong></p>
+                    <p>
+                        A live webcast and recording of the Code4Lib Conference is provided to ensure the entire community can participate. Sponsor benefits will include:
+                    </p>
+                    <ul>
+                        <li>Name / Logo in or next to video streaming window</li>
+                        <li>Small logo on the conference website as Streaming Video Sponsor</li>
+                        <li>Small logo on Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Name on the conference T-shirt</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="col-12">
                 <div class="thumbnail">
                     <a name="Captioning"></a>
-                    <h3>Captioning</h3>
-                    <p><strong><span class="text-danger">5 available</span> at $1,500 (one per day)</strong></p>
+                    <h3>Captioning Sponsor</h3>
+                    <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
                         To facilitate universal participation and access to conference content, real-time live transcription and closed captioning of all presentations, lightning talks, and announcements at the annual Code4Lib conference will be included with the webstream, along with full transcription after the fact to accompany recordings. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Acknowledgement in Published Captions and Transcripts</li>
                         <li>Small logo on the conference website as Captioning Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                         <li>Name on the conference T-shirt</li>
-                        <li>Exhibitor Booth (details dependent on Conference Platform)</li>
                     </ul>
                 </div>
             </div>
@@ -245,21 +264,103 @@ published: true
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Video-Production"></a>
-                    <h3>Post-Conference Video Production</h3>
-
-                    <p><strong><span class="text-danger">5 available</span> at $1,500 (one per day)</strong></p>
+                    <h3>Post-Conference Video Production Sponsor</h3>
+                    <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
-                        Each day of Code4Lib {{site.data.conf.year}} will be shared on the Code4Lib YouTube Channel. Before the videos are posted, they will be captioned and edited, and a closing screen with a Thank You to the day's Sponsor will be added to the end of each video. Sponsor benefits include:
+                        Each day of the annual Code4Lib conference will be shared on the Code4Lib YouTube Channel. After the conference has ended, the videos will be reviewed, re-captioned and edited (as needed), and a closing screen with a Thank You to the Sponsor will be added to the end of each video. Sponsor benefits include:
+                    </p>
                     <ul>
-                        <li>Acknowledgement on Published Video</li>
+                        <li>Acknowledgement on Final Published Video</li>
                         <li>Small logo on the conference website as Video Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" as displayed throughout conference</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                         <li>Name on the conference T-shirt</li>
-                        <li>Exhibitor Booth (details dependent on Conference Platform)</li>
                     </ul>
                 </div>
             </div>
+
+
+            <div class="col-12">
+                <div class="thumbnail">
+                    <a name="Food"></a>
+                    <h3>Food & Beverage Sponsors</h3>
+                    <p>
+                        <strong><span class="text-danger">5 Break Sponsors</span> at $2,000</strong>
+                        <strong><span class="text-danger">3 Breakfast Sponsors</span> at $3,000</strong>
+                        <strong><span class="text-danger">2 Lunch Sponsors</span> at $4,000</strong>
+                    </p>
+                    <p>
+                        Each year, almost 20% of our attendees identify that they have dietary needs that we need to be aware of and accommodate. This includes vegan or vegetarian diets, allergies and/or sensitivities to gluten, dairy, nuts, and so much more. The Code4Lib community is committed to providing meals to all of our conference attendees so everyone is included in the dining events. There is a cost to ensuring that everyone’s needs are met. This sponsorship will be used to provide meals and ensure accurate labeling that accommodates each of our attendee’s needs. Sponsor benefits will include:
+                    </p>
+                    <ul>
+                        <li>Signage at the sponsored meal acknowledging the Sponsor</li>
+                        <li>Small logo on the conference website as Food & Beverage Sponsor</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Logo on the forthcoming Menu website page</li>
+                        <li>Name on the conference T-shirt (OR small logo if sponsoring at $3,000 or more)</li>
+                    </ul>
+                </div>
+            </div>
+
+
+            <div class="col-12">
+                <div class="thumbnail">
+                    <a name="Transportation"></a>
+                    <h3>Transportation Sponsorship</h3>
+                    <p><strong><span class="text-danger">1 available</span> at $2,000</strong></p>
+                    <p>
+                        This sponsorship opportunity ensures that individuals with mobility needs (wheelchair accessibility, door-to-door assistance, etc.) face fewer barriers when participating in C4L events. Transportation options may include shuttle buses and/or metro rail cards, as needed. Sponsor benefits will include:
+                    </p>
+                    <ul>
+                        <li>Signage acknowledging the Sponsor</li>
+                        <li>Small logo on the conference website as Transportation Sponsor</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Name on the conference T-shirt</li>
+                    </ul>
+                </div>
+            </div>
+
+
+            <div class="col-12">
+                <div class="thumbnail">
+                    <a name="Diversity"></a>
+                    <h3>Diversity Scholarships</h3>
+                    <p><strong><span class="text-danger">6 available</span> at $1,500</strong></p>
+                    <p>*Note: Funds have carried over from previous conferences and we have the majority of our Diversity Scholarships already funded for this year.</p>
+                    <p>
+                        These scholarships provide travel costs and conference fees for qualified applicants from groups typically underrepresented at the conference, including women, transgender people, and underrepresented ethnic and racial groups. Applicants must be interested in actively contributing to the mission and goals of the Code4Lib Conference. Sponsor benefits will include:
+                    </p>
+                    <ul>
+                        <li>Logo on forthcoming Scholarships website page</li>
+                        <li>Recognition from podium when scholarship winners are announced</li>
+                        <li>Recognition in emails sent out about scholarships</li>
+                    </ul>
+                </div>
+            </div>
+
+
         </div>
+
+        <!-- Exhibitor Tables -->
+        <div class="row" id="exhibitorTables">
+            <a name="Exhibitor-Tables"></a>
+            <div class="col-12">
+                <h2>Exhibitor Tables</h2>
+            </div>
+
+            <div class="col-12">
+                <ul>
+                    <li><strong>Non-profit organization: $500</strong></li>
+                    <li><strong>For-profit organization, early-bird (on or before April 1, 2022): $900</strong></li>
+                    <li><strong>For-profit organization, normal rate: $1,300</strong></li>
+                    <li><strong>5 available</strong></li>
+                </ul>
+            </div>
+
+            <div class="col-12">
+                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with the Code4lib community on-site, and visibility throughout the conference. Participants will be able to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately following daily sessions. General sponsors are encouraged to also get exhibitor tables.</p>
+            </div>
+        </div>
+
     </div>
 </section>
 

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -223,7 +223,7 @@ published: true
             </div>
 
             <div class="col-12">
-                <p>Code4Lib seeks to provide a welcoming, inclusive, professionally engaging, fun, and safe conference (and ongoing community) experience for everyone. To accomplish this, we are re-focusing our previously named “Targeted Sponsors” on Diversity, Accessibility and Inclusion. Each of the sponsorship opportunities listed below, are aimed at providing an inclusive experience for all of our attendees.</p>
+                <p>Code4Lib seeks to provide a conference and ongoing community that is welcoming, inclusive, professionally engaging, fun, and a safe experience for everyone.</p>
             </div>
 
 


### PR DESCRIPTION
This PR updates the prospectus information at `/prospectus` for 2022.

**To test:**
1. Checkout the issue28 branch, build the site locally, and visit [http://127.0.0.1:4000/prospectus/](http://127.0.0.1:4000/prospectus/)
2. Compare the prospectus sponsorship information on the site to the [details provided by Concentra](https://docs.google.com/document/d/14BxgSoJ4Es67Zc94ep6VJ8Z82wp6jPh0VX8LurvSpV4/edit). They should match.

Closes #28 

