### PR TITLE
fix 2 ARIA problems with speaker pages

### DIFF
--- a/_includes/speaker_box.html
+++ b/_includes/speaker_box.html
@@ -3,7 +3,7 @@
 <div class="speaker-box text-center" id="{{ speaker.id }}-id" data-speaker-info="#{{ speaker.id }}-info">
     <div class="speaker-box-inner">
             <img class="clip-circle-lg" src="{{ speaker.image_src | relative_url }}" alt="{{ speaker.name }}">
-        <h2 class="h4 speaker-name"><a href="#" class="speaker-info-toggle" data-target="#{{ speaker.id }}" aria-expanded="false" aria-controls="{{ speaker.id }}">{{ speaker.name }}</a></h2>
+        <h2 class="h4 speaker-name"><a href="#" class="speaker-info-toggle" data-target="#{{ speaker.id }}" aria-expanded="false" aria-controls="{{ speaker.id }}-info">{{ speaker.name }}</a></h2>
         <div class="speaker-mini">
             <p class="speaker-title">{{ speaker.work_title }}</p>
             <p class="speaker-inst">{{ speaker.institution }}</p>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -85,7 +85,7 @@ jQuery(document).ready(function($){
 //    }
 
     function toggleSpeaker(target){
-        var shownHeight;
+        let shownHeight;
 
         if ($('.speaker-info.show').length){
             shownHeight = $('.speaker-info.show').height();
@@ -96,6 +96,7 @@ jQuery(document).ready(function($){
         $('html, body').animate({
             scrollTop: $(target+'-id').offset().top - shownHeight
         }, 500);
+
         if (!$(target+'-id').hasClass('show')){
                 $('.speaker-info').removeClass('show');
                 $('.speaker-box').removeClass('selected');
@@ -110,7 +111,13 @@ jQuery(document).ready(function($){
 
     $('.speaker-info-toggle').click(function(e){
         e.preventDefault();
-        var target = $(this).data('target');
+        let toggle = $(this);
+        // any other expanded bio is now closed & this one is open
+        $('.speaker-info-toggle')
+            .filter((idx, el) => $(el).attr('aria-expanded') == 'true')
+            .attr('aria-expanded', 'false');
+        toggle.attr('aria-expanded', 'true');
+        let target = toggle.data('target');
         toggleSpeaker(target);
     });
 


### PR DESCRIPTION
This addresses two accessibility problems on the speakers and past keynotes pages.

1. the `aria-expanded` attributes of the speaker name links does not toggle, it simply stays "false" all the time even when a speaker's info box is displayed
2. `aria-controls` attributes target non-existent elements

See [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) for `aria-expanded` reference. It's my understanding that the control must reflect the state of the controlled element, but the controlled element itself does not need any particular ARIA properties.

To test:

- apply the PR
- visit the past keynotes page http://127.0.0.1:4000/speakers/past-keynotes
- inspect the HTML of the name of a particular keynoter
  + their `aria-expanded` attribute should be "false"
  + their `aria-controls` value should match the `id` of the corresponding `.speaker-info` box beneath
- click the keynoter's name link
- their `aria-expanded` attribute should now be "true"
- click _another_ keynoter's name link
- the original speaker's `aria-expanded` attribute should be "false"
- the new speaker's `aria-expanded` attribute should be "true"

Since these changes are to a speaker_box.html include they should fix both the past keynotes page _and_ the regular speakers page http://127.0.0.1:4000/speakers/ but if you want to test that page, you first need to copy our example data (_data/examples/speakers.yml) into the _data directory.