### PR TITLE
update logic to handle != nil value for venue.name

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -66,7 +66,7 @@ state: 'NY'
 #       to a physical conference venue, when the conference is fully online.
 venue:
     reserved-room-block: false
-    name: ''
+    name:
     street: ''
     postal-code: ''
     phone: ''

--- a/_includes/homepage/jumbotron.html
+++ b/_includes/homepage/jumbotron.html
@@ -18,10 +18,10 @@
                 <h1 class="text-right">
                     <span class="sr-only">code for lib {{site.data.conf.year}}</span>
                     {{site.data.conf.location}}
-                    {% if site.data.conf.venue.name != '' %}
-                    <small>{{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}} {{site.data.conf.year}}</small>
+                    {% if site.data.conf.venue.name != nil %}
+                        <small>{{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}} &#8226; Online</small>
                     {% else %}
-                    <small>{{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}} &#8226; Online</small>
+                        <small>{{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}} {{site.data.conf.year}}</small>
                     {% endif %}
                 </h1>
 

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ title: code4lib 2022
             <div class="col-lg-9 col-md-7 col-xs-12">
                 <h2>Welcome to {{site.data.conf.location}}, {{site.data.conf.venue.catchline}}</h2>
                 <p>{{site.data.conf.venue.welcome-message}}</p>
-                {% if site.data.conf.venue.name != '' %}
+                {% if site.data.conf.venue.name != nil %}
                 <p>
                     The conference will take place at the <a href="{{site.data.conf.venue.website}}">{{site.data.conf.venue.name}}</a>,
                     right in downtown {{ site.data.conf.location }}.


### PR DESCRIPTION
This is a resolution to issue #42 and partial work towards both #8 and #41. This will remove the "online" designation in the jumbotron and ensure that the welcome message does not display location, when `venue.name` is nil.