### PR TITLE
Prospectus page outlining reworked

### DIFF
--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -10,49 +10,71 @@ published: true
             <div class="col-12">
                 <h1>Code4Lib {{site.data.conf.year}} Sponsor Prospectus</h1>
                 <p>
-                    <img src="{{ site.baseurl }}/assets/img/persistent/prospectus-collage.jpg" title="Credit sdellis on Twitter" alt="Code4Lib Collage" width="100%">
+                    <img src="{{ site.baseurl }}/assets/img/persistent/prospectus-collage.jpg"
+                        title="Credit sdellis on Twitter" alt="Code4Lib Collage" width="100%">
                 </p>
                 <p>
-                  The Code4Lib {{site.data.conf.year}} Conference, scheduled for {{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}}{% if site.data.conf.venue.name != '' %} in {{site.data.conf.location}}{% endif %}, presents an opportunity for vendors, organizations, libraries, and projects to show their support for open and collaborative solutions for higher education, libraries, museums, and archives by providing financial support and attending the conference.
+                    The Code4Lib {{site.data.conf.year}} Conference, scheduled for {{site.data.conf.days[0].date-data |
+                    date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}}{% if
+                    site.data.conf.venue.name != '' %} in {{site.data.conf.location}}{% endif %}, presents an
+                    opportunity for vendors, organizations, libraries, and projects to show their support for open and
+                    collaborative solutions for higher education, libraries, museums, and archives by providing
+                    financial support and attending the conference.
                 </p>
 
                 <h2>Who We Are</h2>
                 <p>
-                  We are a community of developers and technologists for galleries, libraries, museums, and archives. Code4Lib began as a simple mailing list in 2003, and has grown to become a vibrant community of more than 3,500.
+                    We are a community of developers and technologists for galleries, libraries, museums, and archives.
+                    Code4Lib began as a simple mailing list in 2003, and has grown to become a vibrant community of more
+                    than 3,500.
                 </p>
 
                 <p>
-                  Code4Lib is a community, not an organization. There are no officers or by-laws, but the Code4Lib community has demonstrated strong commitment to the following principles over the years:
-                  <ul>
+                    Code4Lib is a community, not an organization. There are no officers or by-laws, but the Code4Lib
+                    community has demonstrated strong commitment to the following principles over the years:
+                <ul>
                     <li>openness and collaboration</li>
                     <li>diversity and inclusiveness</li>
                     <li>technical excellence</li>
                     <li>a supportive and nurturing space for newcomers</li>
-                  </ul>
+                </ul>
                 </p>
 
                 <h2>About the Conference</h2>
                 <p>
-                  Each year, the Code4Lib conference helps revitalize the community as participants meet in person to discuss new and ongoing projects in a single-track format with short presentations and talks. It also provides in-depth participatory learning experiences through its volunteer-led post-conference programs, and offers ad-hoc breakout sessions focused on collaboration around topics of interest.
-                  <ul>
-                    <li>Conference speakers and programs are chosen by a voting process open to the entire community.</li>
-                    <li>Sessions are live-streamed to support remote attendance. Beginning in 2016, the stream was captioned in real-time to promote accessibility, and the community is committed to continuing this service.</li>
+                    Each year, the Code4Lib conference helps revitalize the community as participants meet in person to
+                    discuss new and ongoing projects in a single-track format with short presentations and talks. It
+                    also provides in-depth participatory learning experiences through its volunteer-led post-conference
+                    programs, and offers ad-hoc breakout sessions focused on collaboration around topics of interest.
+                <ul>
+                    <li>Conference speakers and programs are chosen by a voting process open to the entire community.
+                    </li>
+                    <li>Sessions are live-streamed to support remote attendance. Beginning in 2016, the stream was
+                        captioned in real-time to promote accessibility, and the community is committed to continuing
+                        this service.</li>
                     <!--<li>Diversity scholarships help members of underrepresented communities attend the conference and take advantage of learning and networking opportunities. Many individual community members donate personally to increase the number of scholarships.</li>-->
-                    <li>Our single-track format promotes broad sharing of ideas; the 20-minute time limit for presentations allows topics on a wide variety of technologies.</li>
-                  </ul>
+                    <li>Our single-track format promotes broad sharing of ideas; the 20-minute time limit for
+                        presentations allows topics on a wide variety of technologies.</li>
+                </ul>
                 </p>
 
                 <p>
-                  Code4Lib held its first face-to-face meeting in 2005 in Chicago. The first official annual conference was held in 2006 in Corvallis, Oregon, with 150 attendees. Past conferences typically sell out quickly.
+                    Code4Lib held its first face-to-face meeting in 2005 in Chicago. The first official annual
+                    conference was held in 2006 in Corvallis, Oregon, with 150 attendees. Past conferences typically
+                    sell out quickly.
                 </p>
 
                 <p>
-                  The conference is gender-diverse, with approximately 48% women attendees.
+                    The conference is gender-diverse, with approximately 48% women attendees.
                 </p>
 
                 <h2>Impact of Support</h2>
                 <p>
-                  Code4Lib offers a nexus for technical professionals from galleries, libraries, museums, and archives. Through sponsoring the conference, you can help create connections between projects and individuals, encourage good ideas to cross the gaps between subcommunities, and spawn new ideas. You can also help practitioners level up their skills in technology as well as collaboration with professionals in different areas of expertise.
+                    Code4Lib offers a nexus for technical professionals from galleries, libraries, museums, and
+                    archives. Through sponsoring the conference, you can help create connections between projects and
+                    individuals, encourage good ideas to cross the gaps between subcommunities, and spawn new ideas. You
+                    can also help practitioners level up their skills in technology as well as collaboration with
+                    professionals in different areas of expertise.
                 </p>
 
                 <!-- <p>
@@ -60,26 +82,36 @@ published: true
                 </p> -->
 
                 <p>
-                  Your sponsorship of the conference can also provide immediate, concrete benefits to you and your organization. Code4Lib attendees include active practitioners who may be interested in your product, open source project, or services as well as department heads and senior administrators (approximately 17% of attendees last year) who make purchase decisions. Sponsors are strongly encouraged to send their staff to the conference to take advantage of access to the people and ideas who make up the Code4Lib community.
+                    Your sponsorship of the conference can also provide immediate, concrete benefits to you and your
+                    organization. Code4Lib attendees include active practitioners who may be interested in your product,
+                    open source project, or services as well as department heads and senior administrators
+                    (approximately 17% of attendees last year) who make purchase decisions. Sponsors are strongly
+                    encouraged to send their staff to the conference to take advantage of access to the people and ideas
+                    who make up the Code4Lib community.
                 </p>
 
                 {% if site.data.conf.sponsor-contact-email != nil or site.data.conf.sponsor-btn-link != nil %}
                 <p>
                     {% if site.data.conf.sponsor-btn-link != nil %}
-                        If you're ready to make a pledge, please <a href="{{site.data.conf.sponsor-btn-link}}">visit our sponsor registration form</a>.
+                    If you're ready to make a pledge, please <a href="{{site.data.conf.sponsor-btn-link}}">visit our
+                        sponsor registration form</a>.
                     {% endif %}
                     {% if site.data.conf.sponsor-contact-email != nil %}
-                        If you have questions, please get in touch with <a href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
+                    If you have questions, please get in touch with <a
+                        href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
                     {% endif %}
                 </p>
                 {% if site.data.conf.sponsor-btn-link != nil %}
-                    <a class="btn ct-btn-light btn-lg" href="{{site.data.conf.sponsor-btn-link}}">Sponsor Code4Lib {{site.data.conf.year}}</a>
+                <a class="btn ct-btn-light btn-lg" href="{{site.data.conf.sponsor-btn-link}}">Sponsor Code4Lib
+                    {{site.data.conf.year}}</a>
                 {% endif %}
                 {% endif %}
 
                 {% if site.data.conf.prospectus-document != nil %}
                 <p>
-                    A <a href="{{ site.data.conf.prospectus-document }}" onclick="ga('send', 'event', 'PDF', 'Download', 'Prospectus');">one-page information sheet</a> (PDF) is available to assist with making a case to sponsor the Code4Lib Conference.
+                    A <a href="{{ site.data.conf.prospectus-document }}"
+                        onclick="ga('send', 'event', 'PDF', 'Download', 'Prospectus');">one-page information sheet</a>
+                    (PDF) is available to assist with making a case to sponsor the Code4Lib Conference.
                 </p>
                 {% endif %}
 
@@ -92,8 +124,8 @@ published: true
     <div class="container">
         <div class="row">
             <div class="col-12">
-                <h1>Sponsorship Opportunities</h1>
-                <h2>General sponsorship levels</h2>
+                <h2>Sponsorship Opportunities</h2>
+                <h3>General sponsorship levels</h3>
             </div>
         </div>
 
@@ -102,20 +134,21 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="trophy badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#trophy-badge"></use>
+                        <use class="sponsor-badge"
+                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#trophy-badge"></use>
                     </svg>
-                    <h3>Platinum</h3>
+                    <h4>Platinum</h4>
                     <p><strong>$8,000 and above</strong></p>
                     <ul>
-                      <li>Acknowledgement during opening and closing sessions</li>
-                      <li>Large logo on conference website as Platinum Sponsor</li>
-                      <li>Large logo on Conference "Screensaver" (to be displayed throughout conference)</li>
-                      <li>Large logo on conference T-shirt (b&amp;w vector image required)</li>
-                      <li>$1,000 contribution to the Diversity, Accessibility and Inclusion Fund</li>
-                      <li>Exhibitor Table</li>
-                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
-                      <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
-                      <li>2 free conference registrations</li>
+                        <li>Acknowledgement during opening and closing sessions</li>
+                        <li>Large logo on conference website as Platinum Sponsor</li>
+                        <li>Large logo on Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Large logo on conference T-shirt (b&amp;w vector image required)</li>
+                        <li>$1,000 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                        <li>Exhibitor Table</li>
+                        <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
+                        <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
+                        <li>2 free conference registrations</li>
                     </ul>
                 </div>
             </div>
@@ -123,20 +156,21 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="gold badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge gold" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
+                        <use class="sponsor-badge gold"
+                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
                     </svg>
-                    <h3>Gold</h3>
+                    <h4>Gold</h4>
                     <p><strong>$5,000 - $7,999</strong></p>
                     <ul>
-                      <li>Acknowledgement during opening and closing sessions</li>
-                      <li>Medium logo on the conference website as Gold Sponsor</li>
-                      <li>Medium logo on Conference "Screensaver" (to be displayed throughout conference)</li>
-                      <li>Medium logo on conference T-shirt (b&amp;w vector image required)</li>
-                      <li>$500 contribution to the Diversity, Accessibility and Inclusion Fund</li>
-                      <li>Exhibitor Table</li>
-                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
-                      <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
-                      <li>1 free conference registration</li>
+                        <li>Acknowledgement during opening and closing sessions</li>
+                        <li>Medium logo on the conference website as Gold Sponsor</li>
+                        <li>Medium logo on Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Medium logo on conference T-shirt (b&amp;w vector image required)</li>
+                        <li>$500 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                        <li>Exhibitor Table</li>
+                        <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
+                        <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
+                        <li>1 free conference registration</li>
                     </ul>
                 </div>
             </div>
@@ -147,17 +181,18 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="silver badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge silver" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
+                        <use class="sponsor-badge silver"
+                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
                     </svg>
-                    <h3>Silver</h3>
+                    <h4>Silver</h4>
                     <p><strong>$3,000 - $4,999</strong></p>
                     <ul>
-                      <li>Acknowledgement during opening and closing sessions</li>
-                      <li>Small logo on the conference website as Silver Sponsor</li>
-                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
-                      <li>Small logo on Conference T-shirt (b&amp;w vector image required)</li>
-                      <li>$250 contribution to the Diversity, Accessibility and Inclusion Fund</li>
-                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
+                        <li>Acknowledgement during opening and closing sessions</li>
+                        <li>Small logo on the conference website as Silver Sponsor</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Small logo on Conference T-shirt (b&amp;w vector image required)</li>
+                        <li>$250 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                        <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
                     </ul>
                 </div>
             </div>
@@ -165,16 +200,17 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="bronze badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge bronze" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
+                        <use class="sponsor-badge bronze"
+                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
                     </svg>
-                    <h3>Bronze</h3>
+                    <h4>Bronze</h4>
                     <p><strong>$1,500 - $2,999</strong></p>
                     <ul>
-                      <li>Acknowledgement during opening and closing sessions</li>
-                      <li>Small logo on the conference website as Bronze Sponsor</li>
-                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
-                      <li>Name on conference T-shirt</li>
-                      <li>$100 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                        <li>Acknowledgement during opening and closing sessions</li>
+                        <li>Small logo on the conference website as Bronze Sponsor</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Name on conference T-shirt</li>
+                        <li>$100 contribution to the Diversity, Accessibility and Inclusion Fund</li>
                     </ul>
                 </div>
             </div>
@@ -185,14 +221,15 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="contributor badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#star-badge"></use>
+                        <use class="sponsor-badge"
+                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#star-badge"></use>
                     </svg>
-                    <h3>Contributor</h3>
+                    <h4>Contributor</h4>
                     <p><strong>$750 - $1,499</strong></p>
                     <ul>
-                      <li>Acknowledgement during opening and closing sessions</li>
-                      <li>Small logo on the conference website as Contributor Sponsor</li>
-                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                        <li>Acknowledgement during opening and closing sessions</li>
+                        <li>Small logo on the conference website as Contributor Sponsor</li>
+                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                     </ul>
                 </div>
             </div>
@@ -200,9 +237,10 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="contributor badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#thumbs-badge"></use>
+                        <use class="sponsor-badge"
+                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#thumbs-badge"></use>
                     </svg>
-                    <h3>Supporter</h3>
+                    <h4>Supporter</h4>
                     <p><strong>$300 - $749</strong></p>
                     <ul>
                         <li>Small logo on the conference website as Supporter Sponsor</li>
@@ -216,22 +254,27 @@ published: true
         <div class="row" id="targetedSponsorship">
             <a name="Targeted-Sponsorship"></a>
             <div class="col-12">
-                <h2>Diversity, Accessibility and Inclusion Sponsorships</h2>
+                <h3>Diversity, Accessibility and Inclusion Sponsorships</h3>
             </div>
 
             <div class="col-12">
-                <p>Code4Lib seeks to provide a conference and ongoing community that is welcoming, inclusive, professionally engaging, fun, and a safe experience for everyone.</p>
-                <p>To accomplish this, we are re-focusing our previously named “Targeted Sponsors” on Diversity, Accessibility and Inclusion. Each of the sponsorship opportunities listed below, are aimed at providing an inclusive experience for all of our attendees, and can be purchased alone, or added onto a General Sponsorship purchase.</p>
+                <p>Code4Lib seeks to provide a conference and ongoing community that is welcoming, inclusive,
+                    professionally engaging, fun, and a safe experience for everyone.</p>
+                <p>To accomplish this, we are re-focusing our previously named “Targeted Sponsors” on Diversity,
+                    Accessibility and Inclusion. Each of the sponsorship opportunities listed below, are aimed at
+                    providing an inclusive experience for all of our attendees, and can be purchased alone, or added
+                    onto a General Sponsorship purchase.</p>
             </div>
 
 
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Streaming"></a>
-                    <h3>Streaming Video Sponsor</h3>
+                    <h4>Streaming Video Sponsor</h4>
                     <p><strong><span class="text-danger">2 available</span> at $2,500</strong></p>
                     <p>
-                        A live webcast and recording of the Code4Lib Conference is provided to ensure the entire community can participate. Sponsor benefits will include:
+                        A live webcast and recording of the Code4Lib Conference is provided to ensure the entire
+                        community can participate. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Name / Logo in or next to video streaming window</li>
@@ -245,10 +288,13 @@ published: true
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Captioning"></a>
-                    <h3>Captioning Sponsor</h3>
+                    <h4>Captioning Sponsor</h4>
                     <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
-                        To facilitate universal participation and access to conference content, real-time live transcription and closed captioning of all presentations, lightning talks, and announcements at the annual Code4Lib conference will be included with the webstream, along with full transcription after the fact to accompany recordings. Sponsor benefits will include:
+                        To facilitate universal participation and access to conference content, real-time live
+                        transcription and closed captioning of all presentations, lightning talks, and announcements at
+                        the annual Code4Lib conference will be included with the webstream, along with full
+                        transcription after the fact to accompany recordings. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Acknowledgement in Published Captions and Transcripts</li>
@@ -262,10 +308,13 @@ published: true
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Video-Production"></a>
-                    <h3>Post-Conference Video Production Sponsor</h3>
+                    <h4>Post-Conference Video Production Sponsor</h4>
                     <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
-                        Each day of the annual Code4Lib conference will be shared on the Code4Lib YouTube Channel. After the conference has ended, the videos will be reviewed, re-captioned and edited (as needed), and a closing screen with a Thank You to the Sponsor will be added to the end of each video. Sponsor benefits include:
+                        Each day of the annual Code4Lib conference will be shared on the Code4Lib YouTube Channel. After
+                        the conference has ended, the videos will be reviewed, re-captioned and edited (as needed), and
+                        a closing screen with a Thank You to the Sponsor will be added to the end of each video. Sponsor
+                        benefits include:
                     </p>
                     <ul>
                         <li>Acknowledgement on Final Published Video</li>
@@ -280,14 +329,20 @@ published: true
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Food"></a>
-                    <h3>Food & Beverage Sponsors</h3>
+                    <h4>Food & Beverage Sponsors</h4>
                     <p>
                         <strong><span class="text-danger">5 Break Sponsors</span> at $2,000</strong>
                         <strong><span class="text-danger">3 Breakfast Sponsors</span> at $3,000</strong>
                         <strong><span class="text-danger">2 Lunch Sponsors</span> at $4,000</strong>
                     </p>
                     <p>
-                        Each year, almost 20% of our attendees identify that they have dietary needs that we need to be aware of and accommodate. This includes vegan or vegetarian diets, allergies and/or sensitivities to gluten, dairy, nuts, and so much more. The Code4Lib community is committed to providing meals to all of our conference attendees so everyone is included in the dining events. There is a cost to ensuring that everyone’s needs are met. This sponsorship will be used to provide meals and ensure accurate labeling that accommodates each of our attendee’s needs. Sponsor benefits will include:
+                        Each year, almost 20% of our attendees identify that they have dietary needs that we need to be
+                        aware of and accommodate. This includes vegan or vegetarian diets, allergies and/or
+                        sensitivities to gluten, dairy, nuts, and so much more. The Code4Lib community is committed to
+                        providing meals to all of our conference attendees so everyone is included in the dining events.
+                        There is a cost to ensuring that everyone’s needs are met. This sponsorship will be used to
+                        provide meals and ensure accurate labeling that accommodates each of our attendee’s needs.
+                        Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Signage at the sponsored meal acknowledging the Sponsor</li>
@@ -303,10 +358,13 @@ published: true
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Transportation"></a>
-                    <h3>Transportation Sponsorship</h3>
+                    <h4>Transportation Sponsorship</h4>
                     <p><strong><span class="text-danger">1 available</span> at $2,000</strong></p>
                     <p>
-                        This sponsorship opportunity ensures that individuals with mobility needs (wheelchair accessibility, door-to-door assistance, etc.) face fewer barriers when participating in C4L events. Transportation options may include shuttle buses and/or metro rail cards, as needed. Sponsor benefits will include:
+                        This sponsorship opportunity ensures that individuals with mobility needs (wheelchair
+                        accessibility, door-to-door assistance, etc.) face fewer barriers when participating in C4L
+                        events. Transportation options may include shuttle buses and/or metro rail cards, as needed.
+                        Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Signage acknowledging the Sponsor</li>
@@ -321,11 +379,15 @@ published: true
             <div class="col-12">
                 <div class="thumbnail">
                     <a name="Diversity"></a>
-                    <h3>Diversity Scholarships</h3>
+                    <h4>Diversity Scholarships</h4>
                     <p><strong><span class="text-danger">6 available</span> at $1,500</strong></p>
-                    <p>*Note: Funds have carried over from previous conferences and we have the majority of our Diversity Scholarships already funded for this year.</p>
+                    <p>*Note: Funds have carried over from previous conferences and we have the majority of our
+                        Diversity Scholarships already funded for this year.</p>
                     <p>
-                        These scholarships provide travel costs and conference fees for qualified applicants from groups typically underrepresented at the conference, including international attendees, transgender people, and underrepresented ethnic and racial groups. Applicants must be interested in actively contributing to the mission and goals of the Code4Lib Conference. Sponsor benefits will include:
+                        These scholarships provide travel costs and conference fees for qualified applicants from groups
+                        typically underrepresented at the conference, including international attendees, transgender
+                        people, and underrepresented ethnic and racial groups. Applicants must be interested in actively
+                        contributing to the mission and goals of the Code4Lib Conference. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Logo on forthcoming Scholarships website page</li>
@@ -342,7 +404,7 @@ published: true
         <div class="row" id="exhibitorTables">
             <a name="Exhibitor-Tables"></a>
             <div class="col-12">
-                <h2>Exhibitor Tables</h2>
+                <h3>Exhibitor Tables</h3>
             </div>
 
             <div class="col-12">
@@ -354,7 +416,10 @@ published: true
             </div>
 
             <div class="col-12">
-                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with the Code4lib community on-site, and visibility throughout the conference. Participants will be able to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately following daily sessions. General sponsors are encouraged to also get exhibitor tables.</p>
+                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with
+                    the Code4lib community on-site, and visibility throughout the conference. Participants will be able
+                    to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately
+                    following daily sessions. General sponsors are encouraged to also get exhibitor tables.</p>
             </div>
         </div>
 
@@ -366,9 +431,11 @@ published: true
 <div id="contact">
     <p class="contact-tab">CONTACT</p>
     <div class="thumbnail" id="contact_inner">
-        <h3>Sponsor Contact</h3>
+        <h2>Sponsor Contact</h2>
         <p>
-            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to email <a href="mailto:{{site.data.conf.sponsor-contact-email}}"> {{site.data.conf.sponsor-contact-email}}</a>.
+            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to
+            email <a href="mailto:{{site.data.conf.sponsor-contact-email}}">
+                {{site.data.conf.sponsor-contact-email}}</a>.
         </p>
     </div>
 </div>

--- a/prospectus/index.html
+++ b/prospectus/index.html
@@ -10,71 +10,49 @@ published: true
             <div class="col-12">
                 <h1>Code4Lib {{site.data.conf.year}} Sponsor Prospectus</h1>
                 <p>
-                    <img src="{{ site.baseurl }}/assets/img/persistent/prospectus-collage.jpg"
-                        title="Credit sdellis on Twitter" alt="Code4Lib Collage" width="100%">
+                    <img src="{{ site.baseurl }}/assets/img/persistent/prospectus-collage.jpg" title="Credit sdellis on Twitter" alt="Code4Lib Collage" width="100%">
                 </p>
                 <p>
-                    The Code4Lib {{site.data.conf.year}} Conference, scheduled for {{site.data.conf.days[0].date-data |
-                    date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}}{% if
-                    site.data.conf.venue.name != '' %} in {{site.data.conf.location}}{% endif %}, presents an
-                    opportunity for vendors, organizations, libraries, and projects to show their support for open and
-                    collaborative solutions for higher education, libraries, museums, and archives by providing
-                    financial support and attending the conference.
+                  The Code4Lib {{site.data.conf.year}} Conference, scheduled for {{site.data.conf.days[0].date-data | date: "%B %-d"}} - {{site.data.conf.days.last.date-data | date: "%-d"}}{% if site.data.conf.venue.name != '' %} in {{site.data.conf.location}}{% endif %}, presents an opportunity for vendors, organizations, libraries, and projects to show their support for open and collaborative solutions for higher education, libraries, museums, and archives by providing financial support and attending the conference.
                 </p>
 
                 <h2>Who We Are</h2>
                 <p>
-                    We are a community of developers and technologists for galleries, libraries, museums, and archives.
-                    Code4Lib began as a simple mailing list in 2003, and has grown to become a vibrant community of more
-                    than 3,500.
+                  We are a community of developers and technologists for galleries, libraries, museums, and archives. Code4Lib began as a simple mailing list in 2003, and has grown to become a vibrant community of more than 3,500.
                 </p>
 
                 <p>
-                    Code4Lib is a community, not an organization. There are no officers or by-laws, but the Code4Lib
-                    community has demonstrated strong commitment to the following principles over the years:
-                <ul>
+                  Code4Lib is a community, not an organization. There are no officers or by-laws, but the Code4Lib community has demonstrated strong commitment to the following principles over the years:
+                  <ul>
                     <li>openness and collaboration</li>
                     <li>diversity and inclusiveness</li>
                     <li>technical excellence</li>
                     <li>a supportive and nurturing space for newcomers</li>
-                </ul>
+                  </ul>
                 </p>
 
                 <h2>About the Conference</h2>
                 <p>
-                    Each year, the Code4Lib conference helps revitalize the community as participants meet in person to
-                    discuss new and ongoing projects in a single-track format with short presentations and talks. It
-                    also provides in-depth participatory learning experiences through its volunteer-led post-conference
-                    programs, and offers ad-hoc breakout sessions focused on collaboration around topics of interest.
-                <ul>
-                    <li>Conference speakers and programs are chosen by a voting process open to the entire community.
-                    </li>
-                    <li>Sessions are live-streamed to support remote attendance. Beginning in 2016, the stream was
-                        captioned in real-time to promote accessibility, and the community is committed to continuing
-                        this service.</li>
+                  Each year, the Code4Lib conference helps revitalize the community as participants meet in person to discuss new and ongoing projects in a single-track format with short presentations and talks. It also provides in-depth participatory learning experiences through its volunteer-led post-conference programs, and offers ad-hoc breakout sessions focused on collaboration around topics of interest.
+                  <ul>
+                    <li>Conference speakers and programs are chosen by a voting process open to the entire community.</li>
+                    <li>Sessions are live-streamed to support remote attendance. Beginning in 2016, the stream was captioned in real-time to promote accessibility, and the community is committed to continuing this service.</li>
                     <!--<li>Diversity scholarships help members of underrepresented communities attend the conference and take advantage of learning and networking opportunities. Many individual community members donate personally to increase the number of scholarships.</li>-->
-                    <li>Our single-track format promotes broad sharing of ideas; the 20-minute time limit for
-                        presentations allows topics on a wide variety of technologies.</li>
-                </ul>
+                    <li>Our single-track format promotes broad sharing of ideas; the 20-minute time limit for presentations allows topics on a wide variety of technologies.</li>
+                  </ul>
                 </p>
 
                 <p>
-                    Code4Lib held its first face-to-face meeting in 2005 in Chicago. The first official annual
-                    conference was held in 2006 in Corvallis, Oregon, with 150 attendees. Past conferences typically
-                    sell out quickly.
+                  Code4Lib held its first face-to-face meeting in 2005 in Chicago. The first official annual conference was held in 2006 in Corvallis, Oregon, with 150 attendees. Past conferences typically sell out quickly.
                 </p>
 
                 <p>
-                    The conference is gender-diverse, with approximately 48% women attendees.
+                  The conference is gender-diverse, with approximately 48% women attendees.
                 </p>
 
                 <h2>Impact of Support</h2>
                 <p>
-                    Code4Lib offers a nexus for technical professionals from galleries, libraries, museums, and
-                    archives. Through sponsoring the conference, you can help create connections between projects and
-                    individuals, encourage good ideas to cross the gaps between subcommunities, and spawn new ideas. You
-                    can also help practitioners level up their skills in technology as well as collaboration with
-                    professionals in different areas of expertise.
+                  Code4Lib offers a nexus for technical professionals from galleries, libraries, museums, and archives. Through sponsoring the conference, you can help create connections between projects and individuals, encourage good ideas to cross the gaps between subcommunities, and spawn new ideas. You can also help practitioners level up their skills in technology as well as collaboration with professionals in different areas of expertise.
                 </p>
 
                 <!-- <p>
@@ -82,36 +60,26 @@ published: true
                 </p> -->
 
                 <p>
-                    Your sponsorship of the conference can also provide immediate, concrete benefits to you and your
-                    organization. Code4Lib attendees include active practitioners who may be interested in your product,
-                    open source project, or services as well as department heads and senior administrators
-                    (approximately 17% of attendees last year) who make purchase decisions. Sponsors are strongly
-                    encouraged to send their staff to the conference to take advantage of access to the people and ideas
-                    who make up the Code4Lib community.
+                  Your sponsorship of the conference can also provide immediate, concrete benefits to you and your organization. Code4Lib attendees include active practitioners who may be interested in your product, open source project, or services as well as department heads and senior administrators (approximately 17% of attendees last year) who make purchase decisions. Sponsors are strongly encouraged to send their staff to the conference to take advantage of access to the people and ideas who make up the Code4Lib community.
                 </p>
 
                 {% if site.data.conf.sponsor-contact-email != nil or site.data.conf.sponsor-btn-link != nil %}
                 <p>
                     {% if site.data.conf.sponsor-btn-link != nil %}
-                    If you're ready to make a pledge, please <a href="{{site.data.conf.sponsor-btn-link}}">visit our
-                        sponsor registration form</a>.
+                        If you're ready to make a pledge, please <a href="{{site.data.conf.sponsor-btn-link}}">visit our sponsor registration form</a>.
                     {% endif %}
                     {% if site.data.conf.sponsor-contact-email != nil %}
-                    If you have questions, please get in touch with <a
-                        href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
+                        If you have questions, please get in touch with <a href="mailto:{{site.data.conf.sponsor-contact-email}}">{{site.data.conf.sponsor-contact-email}}</a>.
                     {% endif %}
                 </p>
                 {% if site.data.conf.sponsor-btn-link != nil %}
-                <a class="btn ct-btn-light btn-lg" href="{{site.data.conf.sponsor-btn-link}}">Sponsor Code4Lib
-                    {{site.data.conf.year}}</a>
+                    <a class="btn ct-btn-light btn-lg" href="{{site.data.conf.sponsor-btn-link}}">Sponsor Code4Lib {{site.data.conf.year}}</a>
                 {% endif %}
                 {% endif %}
 
                 {% if site.data.conf.prospectus-document != nil %}
                 <p>
-                    A <a href="{{ site.data.conf.prospectus-document }}"
-                        onclick="ga('send', 'event', 'PDF', 'Download', 'Prospectus');">one-page information sheet</a>
-                    (PDF) is available to assist with making a case to sponsor the Code4Lib Conference.
+                    A <a href="{{ site.data.conf.prospectus-document }}" onclick="ga('send', 'event', 'PDF', 'Download', 'Prospectus');">one-page information sheet</a> (PDF) is available to assist with making a case to sponsor the Code4Lib Conference.
                 </p>
                 {% endif %}
 
@@ -134,21 +102,20 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="trophy badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge"
-                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#trophy-badge"></use>
+                        <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#trophy-badge"></use>
                     </svg>
                     <h4>Platinum</h4>
                     <p><strong>$8,000 and above</strong></p>
                     <ul>
-                        <li>Acknowledgement during opening and closing sessions</li>
-                        <li>Large logo on conference website as Platinum Sponsor</li>
-                        <li>Large logo on Conference "Screensaver" (to be displayed throughout conference)</li>
-                        <li>Large logo on conference T-shirt (b&amp;w vector image required)</li>
-                        <li>$1,000 contribution to the Diversity, Accessibility and Inclusion Fund</li>
-                        <li>Exhibitor Table</li>
-                        <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
-                        <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
-                        <li>2 free conference registrations</li>
+                      <li>Acknowledgement during opening and closing sessions</li>
+                      <li>Large logo on conference website as Platinum Sponsor</li>
+                      <li>Large logo on Conference "Screensaver" (to be displayed throughout conference)</li>
+                      <li>Large logo on conference T-shirt (b&amp;w vector image required)</li>
+                      <li>$1,000 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Exhibitor Table</li>
+                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
+                      <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
+                      <li>2 free conference registrations</li>
                     </ul>
                 </div>
             </div>
@@ -156,21 +123,20 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="gold badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge gold"
-                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
+                        <use class="sponsor-badge gold" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
                     </svg>
                     <h4>Gold</h4>
                     <p><strong>$5,000 - $7,999</strong></p>
                     <ul>
-                        <li>Acknowledgement during opening and closing sessions</li>
-                        <li>Medium logo on the conference website as Gold Sponsor</li>
-                        <li>Medium logo on Conference "Screensaver" (to be displayed throughout conference)</li>
-                        <li>Medium logo on conference T-shirt (b&amp;w vector image required)</li>
-                        <li>$500 contribution to the Diversity, Accessibility and Inclusion Fund</li>
-                        <li>Exhibitor Table</li>
-                        <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
-                        <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
-                        <li>1 free conference registration</li>
+                      <li>Acknowledgement during opening and closing sessions</li>
+                      <li>Medium logo on the conference website as Gold Sponsor</li>
+                      <li>Medium logo on Conference "Screensaver" (to be displayed throughout conference)</li>
+                      <li>Medium logo on conference T-shirt (b&amp;w vector image required)</li>
+                      <li>$500 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Exhibitor Table</li>
+                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
+                      <li>Sponsorship Recognition on the #code4libcon Slack Channel</li>
+                      <li>1 free conference registration</li>
                     </ul>
                 </div>
             </div>
@@ -181,18 +147,17 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="silver badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge silver"
-                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
+                        <use class="sponsor-badge silver" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
                     </svg>
                     <h4>Silver</h4>
                     <p><strong>$3,000 - $4,999</strong></p>
                     <ul>
-                        <li>Acknowledgement during opening and closing sessions</li>
-                        <li>Small logo on the conference website as Silver Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
-                        <li>Small logo on Conference T-shirt (b&amp;w vector image required)</li>
-                        <li>$250 contribution to the Diversity, Accessibility and Inclusion Fund</li>
-                        <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
+                      <li>Acknowledgement during opening and closing sessions</li>
+                      <li>Small logo on the conference website as Silver Sponsor</li>
+                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                      <li>Small logo on Conference T-shirt (b&amp;w vector image required)</li>
+                      <li>$250 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Virtual Promotion to conference attendees (could include video or electronic brochure)</li>
                     </ul>
                 </div>
             </div>
@@ -200,17 +165,16 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="bronze badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge bronze"
-                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
+                        <use class="sponsor-badge bronze" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#medal-badge"></use>
                     </svg>
                     <h4>Bronze</h4>
                     <p><strong>$1,500 - $2,999</strong></p>
                     <ul>
-                        <li>Acknowledgement during opening and closing sessions</li>
-                        <li>Small logo on the conference website as Bronze Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
-                        <li>Name on conference T-shirt</li>
-                        <li>$100 contribution to the Diversity, Accessibility and Inclusion Fund</li>
+                      <li>Acknowledgement during opening and closing sessions</li>
+                      <li>Small logo on the conference website as Bronze Sponsor</li>
+                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                      <li>Name on conference T-shirt</li>
+                      <li>$100 contribution to the Diversity, Accessibility and Inclusion Fund</li>
                     </ul>
                 </div>
             </div>
@@ -221,15 +185,14 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="contributor badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge"
-                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#star-badge"></use>
+                        <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#star-badge"></use>
                     </svg>
                     <h4>Contributor</h4>
                     <p><strong>$750 - $1,499</strong></p>
                     <ul>
-                        <li>Acknowledgement during opening and closing sessions</li>
-                        <li>Small logo on the conference website as Contributor Sponsor</li>
-                        <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
+                      <li>Acknowledgement during opening and closing sessions</li>
+                      <li>Small logo on the conference website as Contributor Sponsor</li>
+                      <li>Small logo on the Conference "Screensaver" (to be displayed throughout conference)</li>
                     </ul>
                 </div>
             </div>
@@ -237,8 +200,7 @@ published: true
             <div class="col-12 col-sm-6 col-md-6">
                 <div class="thumbnail">
                     <svg alt="contributor badge" width="100%" xmlns:xlink="http://www.w3.org/1999/xlink">
-                        <use class="sponsor-badge"
-                            xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#thumbs-badge"></use>
+                        <use class="sponsor-badge" xlink:href="{{ site.baseurl }}/assets/img/badges/badges.svg#thumbs-badge"></use>
                     </svg>
                     <h4>Supporter</h4>
                     <p><strong>$300 - $749</strong></p>
@@ -258,12 +220,8 @@ published: true
             </div>
 
             <div class="col-12">
-                <p>Code4Lib seeks to provide a conference and ongoing community that is welcoming, inclusive,
-                    professionally engaging, fun, and a safe experience for everyone.</p>
-                <p>To accomplish this, we are re-focusing our previously named “Targeted Sponsors” on Diversity,
-                    Accessibility and Inclusion. Each of the sponsorship opportunities listed below, are aimed at
-                    providing an inclusive experience for all of our attendees, and can be purchased alone, or added
-                    onto a General Sponsorship purchase.</p>
+                <p>Code4Lib seeks to provide a conference and ongoing community that is welcoming, inclusive, professionally engaging, fun, and a safe experience for everyone.</p>
+                <p>To accomplish this, we are re-focusing our previously named “Targeted Sponsors” on Diversity, Accessibility and Inclusion. Each of the sponsorship opportunities listed below, are aimed at providing an inclusive experience for all of our attendees, and can be purchased alone, or added onto a General Sponsorship purchase.</p>
             </div>
 
 
@@ -273,8 +231,7 @@ published: true
                     <h4>Streaming Video Sponsor</h4>
                     <p><strong><span class="text-danger">2 available</span> at $2,500</strong></p>
                     <p>
-                        A live webcast and recording of the Code4Lib Conference is provided to ensure the entire
-                        community can participate. Sponsor benefits will include:
+                        A live webcast and recording of the Code4Lib Conference is provided to ensure the entire community can participate. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Name / Logo in or next to video streaming window</li>
@@ -291,10 +248,7 @@ published: true
                     <h4>Captioning Sponsor</h4>
                     <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
-                        To facilitate universal participation and access to conference content, real-time live
-                        transcription and closed captioning of all presentations, lightning talks, and announcements at
-                        the annual Code4Lib conference will be included with the webstream, along with full
-                        transcription after the fact to accompany recordings. Sponsor benefits will include:
+                        To facilitate universal participation and access to conference content, real-time live transcription and closed captioning of all presentations, lightning talks, and announcements at the annual Code4Lib conference will be included with the webstream, along with full transcription after the fact to accompany recordings. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Acknowledgement in Published Captions and Transcripts</li>
@@ -311,10 +265,7 @@ published: true
                     <h4>Post-Conference Video Production Sponsor</h4>
                     <p><strong><span class="text-danger">2 available</span> at $1,500</strong></p>
                     <p>
-                        Each day of the annual Code4Lib conference will be shared on the Code4Lib YouTube Channel. After
-                        the conference has ended, the videos will be reviewed, re-captioned and edited (as needed), and
-                        a closing screen with a Thank You to the Sponsor will be added to the end of each video. Sponsor
-                        benefits include:
+                        Each day of the annual Code4Lib conference will be shared on the Code4Lib YouTube Channel. After the conference has ended, the videos will be reviewed, re-captioned and edited (as needed), and a closing screen with a Thank You to the Sponsor will be added to the end of each video. Sponsor benefits include:
                     </p>
                     <ul>
                         <li>Acknowledgement on Final Published Video</li>
@@ -336,13 +287,7 @@ published: true
                         <strong><span class="text-danger">2 Lunch Sponsors</span> at $4,000</strong>
                     </p>
                     <p>
-                        Each year, almost 20% of our attendees identify that they have dietary needs that we need to be
-                        aware of and accommodate. This includes vegan or vegetarian diets, allergies and/or
-                        sensitivities to gluten, dairy, nuts, and so much more. The Code4Lib community is committed to
-                        providing meals to all of our conference attendees so everyone is included in the dining events.
-                        There is a cost to ensuring that everyone’s needs are met. This sponsorship will be used to
-                        provide meals and ensure accurate labeling that accommodates each of our attendee’s needs.
-                        Sponsor benefits will include:
+                        Each year, almost 20% of our attendees identify that they have dietary needs that we need to be aware of and accommodate. This includes vegan or vegetarian diets, allergies and/or sensitivities to gluten, dairy, nuts, and so much more. The Code4Lib community is committed to providing meals to all of our conference attendees so everyone is included in the dining events. There is a cost to ensuring that everyone’s needs are met. This sponsorship will be used to provide meals and ensure accurate labeling that accommodates each of our attendee’s needs. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Signage at the sponsored meal acknowledging the Sponsor</li>
@@ -361,10 +306,7 @@ published: true
                     <h4>Transportation Sponsorship</h4>
                     <p><strong><span class="text-danger">1 available</span> at $2,000</strong></p>
                     <p>
-                        This sponsorship opportunity ensures that individuals with mobility needs (wheelchair
-                        accessibility, door-to-door assistance, etc.) face fewer barriers when participating in C4L
-                        events. Transportation options may include shuttle buses and/or metro rail cards, as needed.
-                        Sponsor benefits will include:
+                        This sponsorship opportunity ensures that individuals with mobility needs (wheelchair accessibility, door-to-door assistance, etc.) face fewer barriers when participating in C4L events. Transportation options may include shuttle buses and/or metro rail cards, as needed. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Signage acknowledging the Sponsor</li>
@@ -381,13 +323,9 @@ published: true
                     <a name="Diversity"></a>
                     <h4>Diversity Scholarships</h4>
                     <p><strong><span class="text-danger">6 available</span> at $1,500</strong></p>
-                    <p>*Note: Funds have carried over from previous conferences and we have the majority of our
-                        Diversity Scholarships already funded for this year.</p>
+                    <p>*Note: Funds have carried over from previous conferences and we have the majority of our Diversity Scholarships already funded for this year.</p>
                     <p>
-                        These scholarships provide travel costs and conference fees for qualified applicants from groups
-                        typically underrepresented at the conference, including international attendees, transgender
-                        people, and underrepresented ethnic and racial groups. Applicants must be interested in actively
-                        contributing to the mission and goals of the Code4Lib Conference. Sponsor benefits will include:
+                        These scholarships provide travel costs and conference fees for qualified applicants from groups typically underrepresented at the conference, including international attendees, transgender people, and underrepresented ethnic and racial groups. Applicants must be interested in actively contributing to the mission and goals of the Code4Lib Conference. Sponsor benefits will include:
                     </p>
                     <ul>
                         <li>Logo on forthcoming Scholarships website page</li>
@@ -416,10 +354,7 @@ published: true
             </div>
 
             <div class="col-12">
-                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with
-                    the Code4lib community on-site, and visibility throughout the conference. Participants will be able
-                    to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately
-                    following daily sessions. General sponsors are encouraged to also get exhibitor tables.</p>
+                <p>Tables in a high-traffic area provide organizations, projects, and vendors a chance to interact with the Code4lib community on-site, and visibility throughout the conference. Participants will be able to visit tables during the morning and afternoon breaks, lunches, breakout sessions, and immediately following daily sessions. General sponsors are encouraged to also get exhibitor tables.</p>
             </div>
         </div>
 
@@ -433,9 +368,7 @@ published: true
     <div class="thumbnail" id="contact_inner">
         <h2>Sponsor Contact</h2>
         <p>
-            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to
-            email <a href="mailto:{{site.data.conf.sponsor-contact-email}}">
-                {{site.data.conf.sponsor-contact-email}}</a>.
+            If you would like to pledge your support at any level, or have questions about sponsorship, feel free to email <a href="mailto:{{site.data.conf.sponsor-contact-email}}"> {{site.data.conf.sponsor-contact-email}}</a>.
         </p>
     </div>
 </div>


### PR DESCRIPTION
Reworked the bottom half of the page to potentially fix issue #40. 

As headings act as the page content outline, someone familiar with the content should review the page, but here's the gist...
```
<h1>Code4Lib Sponsor Prospectus</h1>

<h2>Who We Are</h2>
<h2>About the Conference</h2>
<h2>Impact of Support</h2>
<h2>Sponsorship Opportunities</h2>
    <h3>General sponsorship levels</h3>
         <h4>Platinum</h4>
         <h4>Gold</h4>
         <h4>Silver</h4>
         <h4>Bronze</h4>
         <h4>Contributor</h4>
         <h4>Supporter</h4>
    <h3>Diversity, Accessibility and Inclusion Sponsorships</h3>
         <h4>Streaming Video Sponsor</h4>
         <h4>Captioning Sponsor</h4>
         <h4>Post-Conference Video Production Sponsor</h4>
         <h4>Food & Beverage Sponsors</h4>
         <h4>Transportation Sponsorship</h4>
         <h4>Diversity Scholarships</h4>
    <h3>Exhibitor Tables</h3>
<h2>Sponsor Contact</h2>
```
Page appearance remained largely the same (slight heading size differences)