### PR TITLE
Fix MIT Libraries link

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -49,7 +49,7 @@
 
 - name: MIT Libraries
   img: /assets/img/sponsors/mit.png
-  link: http://www.google.com
+  link: https://libraries.mit.edu/
   level: silver
   diversity: true
   transcription: false


### PR DESCRIPTION
Fix link to MIT Libraries site on sponsors page