### PR TITLE
Issue #76 mini schedule on the timeline page

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -36,7 +36,7 @@ image-attributions:
 have-talks: false
 have-workshops: false
 # if true Schedule link -> /schedule/, if false -> /schedule/timeline
-have-schedule: false
+have-schedule: true
 
 # day 0 = preconf day
 days:

--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -7,7 +7,7 @@
 workshop-only:
   # "show" only affects a button on the general-info/attend page
   show: false
-  url: "https://na.eventscloud.com/c4l20"
+  url:
   # precon-only registration cost may differ from precons with general registration
   half-day-cost: "$60"
   full-day-cost: "$120"

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -1,0 +1,11 @@
+# Placeholder, copy this file from _data/examples/schedule.yml to _data/schedule.yml
+- timeImg: 9.00.png
+  title: Schedule Forthcoming
+  day1: true
+  day2: true
+  time: 9:00-17:15
+
+- timeImg: 9.00.png
+  title: Schedule Forthcoming
+  day3: true
+  time: 9:00-12:45

--- a/_includes/schedule_nav.html
+++ b/_includes/schedule_nav.html
@@ -2,11 +2,10 @@
   <div class="col-md-6 offset-md-4">
     <nav aria-label="Page navigation">
       <ul class="pagination">
+        <li {% if include.param == "day5" %} class="active page-item" {% endif %}><a href="/workshops" class="page-link">Pre-Conference</a></li>
         <li {% if include.param == "day1" %} class="active page-item" {% endif %}><a href="/schedule/day-1" class="page-link">Day 1</a></li>
         <li {% if include.param == "day2" %} class="active page-item" {% endif %}><a href="/schedule/day-2" class="page-link">Day 2</a></li>
         <li {% if include.param == "day3" %} class="active page-item" {% endif %}><a href="/schedule/day-3" class="page-link">Day 3</a></li>
-        <li {% if include.param == "day4" %} class="active page-item" {% endif %}><a href="/schedule/day-4" class="page-link">Day 4</a></li>
-        <li {% if include.param == "day5" %} class="active page-item" {% endif %}><a href="/workshops" class="page-link">Day 5</a></li>
       </ul>
     </nav>
   </div>

--- a/_layouts/day-schedule.html
+++ b/_layouts/day-schedule.html
@@ -5,7 +5,7 @@
     <div class="row">
         <div class="col-12">
             <h1>{% assign day = page.day | slice: -1 %}
-                {% assign index = day | plus: 0 | minus: 1 %}
+                {% assign index = day | plus: 0 %}
                 {{ page.title }} - {{site.data.conf.days[index].date}}
             </h1>
             {% if site.data.conf.have-schedule %}

--- a/schedule/day-4/index.html
+++ b/schedule/day-4/index.html
@@ -1,7 +1,0 @@
----
-layout: day-schedule
-title: Day 4
-class: schedule
-categories: Schedule
-day: day4
----

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -13,15 +13,18 @@ title: Schedule
 
     <div class="row">
         <div class="col-12 col-md-3 text-right">
-            <h3>12PM to 4PM
+            <h3>9AM to 5PM
                 <br/><div class="timezone">Eastern Time</div>
             </h3>
-
         </div>
         <div class="col-12 col-md-9 sched-well">
-            <h4><a href="/schedule/day-1">General Conference, Day One</a></h4>
+            <h3><a href="/workshops">Pre-Conference Workshops</a></h3>
             <p>
-                Keynote #1 kicks off the conference. Talks have been selected by the community.
+                Pre-conference details are available
+                {% if site.data.registration.workshop-only.url != nil %}
+                    on the <a href="{{site.data.registration.workshop-only.url}}">registration site</a> and
+                {% endif %}
+                on the <a href="/workshops">Pre-Conference Workshops</a> page.
             </p>
         </div>
     </div>
@@ -81,12 +84,12 @@ title: Schedule
 
     <div class="row">
         <div class="col-12 col-md-3 text-right">
-            <h3>12PM to 4PM
+            <h3>9AM to 5:15PM
                 <br/><div class="timezone">Eastern Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
-            <h4><a href="/schedule/day-2">General Conference, Day Two</a></h4>
+            <h4><a href="/schedule/day-1">General Conference, Day One</a></h4>
             <p>
                 Talks have been selected by the community.
             </p>
@@ -143,12 +146,12 @@ title: Schedule
 
     <div class="row">
         <div class="col-12 col-md-3 text-right">
-            <h3>12PM to 4PM
+            <h3>9AM to 5:15PM
                 <br/><div class="timezone">Eastern Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
-            <h4><a href="/schedule/day-3">General Conference, Day Three</a></h4>
+            <h4><a href="/schedule/day-2">General Conference, Day Two</a></h4>
             <p>
                 Talks have been selected by the community.
             </p>
@@ -206,12 +209,12 @@ title: Schedule
 
     <div class="row">
         <div class="col-12 col-md-3 text-right">
-            <h3>12PM to 4PM
+            <h3>9AM to 12:45PM
                 <br/><div class="timezone">Eastern Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
-            <h4><a href="/schedule/day-4">General Conference, Day Four</a></h4>
+            <h4><a href="/schedule/day-3">General Conference, Day Three</a></h4>
             <p>
                 Keynote #2 closes out the conference. Talks have been selected by the community.
             </p>
@@ -238,30 +241,6 @@ title: Schedule
         </div>
     </div>
     {% endif %}
-
-    <div class="row">
-        <div class="col-12 sched-date">
-            <h2>{{site.data.conf.days[4].weekday}}, {{site.data.conf.days[4].date}}</h2>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-12 col-md-3 text-right">
-            <h3>9AM to 5PM
-                <br/><div class="timezone">Eastern Time</div>
-            </h3>
-        </div>
-        <div class="col-12 col-md-9 sched-well">
-            <h3><a href="/workshops">Pre-Conference Workshops</a></h3>
-            <p>
-                Pre-conference details are available
-                {% if site.data.registration.workshop-only.url.size > 0 %}
-                    on the <a href="{{site.data.registration.workshop-only.url}}">registration site</a> and
-                {% endif %}
-                on the <a href="/workshops">Pre-Conference Workshops</a> page.
-            </p>
-        </div>
-    </div>
 
     {% comment %}
         <!-- BoF hangouts section, move to right date/time -->

--- a/schedule/timeline.html
+++ b/schedule/timeline.html
@@ -18,41 +18,5 @@ categories: Schedule
         <div class="row">
             {% include homepage/pre_conference.html %}
         </div>
-
-        <!-- Mini-schedule for use while timeline is still displayed -->
-        <div class="container">
-            <div class="row">
-                <div class="col-12">
-                    <h3 class="expo">Conference Schedule</h3>
-                    <div class="row going-on">
-                        <div class="col-12">
-                        <div class="h4">Monday, May 23, 9am-5pm</div>
-                        <small>Pre-Conference Workshops, details will be available on the registration site and Pre-Conference Workshops page.</small>
-                        </div>
-                    </div>
-                    
-                    <div class="row going-on">
-                        <div class="col-12">
-                        <div class="h4">Tuesday, May 24, 9am-5:15pm</div>
-                        <small>General Conference, Day One</small>
-                        </div>
-                    </div>
-
-                    <div class="row going-on">
-                        <div class="col-12">
-                        <div class="h4">Wednesday, May 25, 9am-5:15pm</div>
-                        <small>General Conference, Day Two</small>
-                        </div>
-                    </div>
-
-                    <div class="row going-on">
-                        <div class="col-12">
-                        <div class="h4">Thursday, May 26, 9am-12:45pm</div>
-                        <small>General Conference, Day Three</small>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 </section>

--- a/schedule/timeline.html
+++ b/schedule/timeline.html
@@ -18,5 +18,41 @@ categories: Schedule
         <div class="row">
             {% include homepage/pre_conference.html %}
         </div>
+
+        <!-- Mini-schedule for use while timeline is still displayed -->
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <h3 class="expo">Conference Schedule</h3>
+                    <div class="row going-on">
+                        <div class="col-12">
+                        <div class="h4">Monday, May 23, 9am-5pm</div>
+                        <small>Pre-Conference Workshops, details will be available on the registration site and Pre-Conference Workshops page.</small>
+                        </div>
+                    </div>
+                    
+                    <div class="row going-on">
+                        <div class="col-12">
+                        <div class="h4">Tuesday, May 24, 9am-5:15pm</div>
+                        <small>General Conference, Day One</small>
+                        </div>
+                    </div>
+
+                    <div class="row going-on">
+                        <div class="col-12">
+                        <div class="h4">Wednesday, May 25, 9am-5:15pm</div>
+                        <small>General Conference, Day Two</small>
+                        </div>
+                    </div>
+
+                    <div class="row going-on">
+                        <div class="col-12">
+                        <div class="h4">Thursday, May 26, 9am-12:45pm</div>
+                        <small>General Conference, Day Three</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </section>


### PR DESCRIPTION
This is for the skeleton schedule. It is a bit awkward because the timeline and schedule both share the same navigation slot so the site expects to only show one or the other. So I added a mini schedule to the timeline page and did my best to make it blend in.