### PR TITLE
don't load newcomer dinner JS without the data

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -299,6 +299,7 @@ trivia-night:
   sign-up-url: ''
   sign-up-button-text: 'Sign Up! Registration Limited'
 
+# see also: dinner.yml file of restaurant locations
 newcomer-dinner:
   show: false
   # entering the URL doubles as a "show more info" switch, too

--- a/_data/examples/dinner.yml
+++ b/_data/examples/dinner.yml
@@ -24,7 +24,7 @@
   takes-reservations: Yes
   can-seat-more-than-one-group-of-6: Yes
   price-point: $10-23
-  accessibility-and-notes: Very loud atmosphere.
+  accessibility-and-notes: Very "rowdy" atmosphere.
 
 - restaurant-name: Place w/o a Website
   city-state: Dublin, Ohio

--- a/_data/examples/dinner.yml
+++ b/_data/examples/dinner.yml
@@ -1,11 +1,4 @@
-- dist: .50-.74
-  hood: Ahood
-  name: A Restaurant Name
-  res: 'no'
-  type: Pub
-  url: '#'
-  veg: 'yes'
-
+# can-seat-more... and price-point are not used in general-info/venues/dinner.html
 - restaurant-name: Apteka
   city-state: Pittsburgh PA
   url: https://aptekapgh.com/
@@ -18,3 +11,30 @@
   price-point: $11-30
   notes:
   accessibility-notes: Accessible entry
+
+- restaurant-name: Foodies Food Palace
+  city-state: Paris, Texas
+  url: https://example.com
+  type-of-food: Barbecue
+  distance-from-hotel: 0.5 miles
+  vegetarian-options: No
+  vegan-options: No
+  takes-reservations: Yes
+  can-seat-more-than-one-group-of-6: Yes
+  price-point: $10-23
+  notes: Very loud atmosphere.
+  accessibility-notes:
+
+
+- restaurant-name: Place w/o a Website
+  city-state: Dublin, Ohio
+  url:
+  type-of-food: Stews
+  distance-from-hotel: 5 miles
+  vegetarian-options: Yes
+  vegan-options: No
+  takes-reservations: Yes
+  can-seat-more-than-one-group-of-6: No
+  price-point: $30-40
+  notes:
+  accessibility-notes:

--- a/_data/examples/dinner.yml
+++ b/_data/examples/dinner.yml
@@ -1,51 +1,42 @@
-# can-seat-more... and city-state are not used on general-info/venues/dinner.html
 # for sorting purposes:
 # - distance should start with a number
 # - price point should start with a $ and then a number
 - restaurant-name: Apteka
-  city-state: Pittsburgh PA
   url: https://aptekapgh.com/
   type-of-food: Vegan
   distance-from-hotel: 1 mile
   vegetarian-options: Yes
   vegan-options: Yes
   takes-reservations: No
-  can-seat-more-than-one-group-of-6: No
   price-point: $11-30
   accessibility-and-notes: Accessible entry.
 
 - restaurant-name: Foodies Food Palace
-  city-state: Paris, Texas
   url: https://example.com
   type-of-food: Barbecue
   distance-from-hotel: 0.5 miles
   vegetarian-options: No
   vegan-options: No
   takes-reservations: Yes
-  can-seat-more-than-one-group-of-6: Yes
   price-point: $10-23
   accessibility-and-notes: Very "rowdy" atmosphere.
 
 - restaurant-name: Place w/o a Website
-  city-state: Dublin, Ohio
   url:
   type-of-food: Stews
   distance-from-hotel: 5 miles
   vegetarian-options: Yes
   vegan-options: No
   takes-reservations: Yes
-  can-seat-more-than-one-group-of-6: No
   price-point: $30-40
   accessibility-and-notes:
 
 - restaurant-name: Plant-based Prandial
-  city-state: Berlin, NH
   url: https://example.com
   type-of-food: Vegan
   distance-from-hotel: 2 miles
   vegetarian-options: No
   vegan-options: Yes
   takes-reservations: Yes
-  can-seat-more-than-one-group-of-6: Yes
   price-point: $15-30
   accessibility-and-notes: Accessible entry.

--- a/_data/examples/dinner.yml
+++ b/_data/examples/dinner.yml
@@ -1,16 +1,18 @@
-# can-seat-more... and price-point are not used in general-info/venues/dinner.html
+# can-seat-more... and city-state are not used on general-info/venues/dinner.html
+# for sorting purposes:
+# - distance should start with a number
+# - price point should start with a $ and then a number
 - restaurant-name: Apteka
   city-state: Pittsburgh PA
   url: https://aptekapgh.com/
   type-of-food: Vegan
-  distance-from-hotel: More than 1 mile
+  distance-from-hotel: 1 mile
   vegetarian-options: Yes
   vegan-options: Yes
   takes-reservations: No
   can-seat-more-than-one-group-of-6: No
   price-point: $11-30
-  notes:
-  accessibility-notes: Accessible entry
+  accessibility-and-notes: Accessible entry.
 
 - restaurant-name: Foodies Food Palace
   city-state: Paris, Texas
@@ -22,9 +24,7 @@
   takes-reservations: Yes
   can-seat-more-than-one-group-of-6: Yes
   price-point: $10-23
-  notes: Very loud atmosphere.
-  accessibility-notes:
-
+  accessibility-and-notes: Very loud atmosphere.
 
 - restaurant-name: Place w/o a Website
   city-state: Dublin, Ohio
@@ -36,5 +36,16 @@
   takes-reservations: Yes
   can-seat-more-than-one-group-of-6: No
   price-point: $30-40
-  notes:
-  accessibility-notes:
+  accessibility-and-notes:
+
+- restaurant-name: Plant-based Prandial
+  city-state: Berlin, NH
+  url: https://example.com
+  type-of-food: Vegan
+  distance-from-hotel: 2 miles
+  vegetarian-options: No
+  vegan-options: Yes
+  takes-reservations: Yes
+  can-seat-more-than-one-group-of-6: Yes
+  price-point: $15-30
+  accessibility-and-notes: Accessible entry.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -37,6 +37,7 @@
 </footer>
 
 <script  src="https://code.jquery.com/jquery-3.4.1.js"  integrity="sha256-WpOohJOqMqqyKL9FccASB9O0KwACQJpFTUBLTYOVvVU="  crossorigin="anonymous"></script>
+{%- comment -%} required for Bootstrap tooltips but not used directly {%- endcomment -%}
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
 <script src="{{ "/assets/js/main.js" | relative_url }}"></script>
@@ -57,14 +58,16 @@
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.13/css/jquery.dataTables.min.css">
 <script src="https://cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
 <script>
-  $(document).ready(function() {
+$(document).ready(function() {
     $('#dinner-datatable').DataTable({
         "paging": false,
         "searching": false,
         "autoWidth": false,
         "order": [[0, 'asc']]
-        });
-    } );
+    })
+})
+// tooltips beside restaurant names
+$('i[role="tooltip"]').each((idx, elem) => $(elem).tooltip())
 </script>
 {% endif %}
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,7 +36,6 @@
     </div>
 </footer>
 
-<!-- <script>window.jQuery || document.write('<script src="{{ "/assets/js/vendor/jquery-1.11.2.min.js" | relative_url }}"><\/script>')</script> -->
 <script  src="https://code.jquery.com/jquery-3.4.1.js"  integrity="sha256-WpOohJOqMqqyKL9FccASB9O0KwACQJpFTUBLTYOVvVU="  crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
@@ -53,9 +52,8 @@
 {% include proposed-js.html %}
 {% endif %}
 
-{% if page.title == 'Venues' %}
+{% if site.data.dinner != nil and page.title == 'Venues' %}
 <script src="https://kit.fontawesome.com/bd2d035961.js" crossorigin="anonymous"></script>
-<script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.js"></script>
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.13/css/jquery.dataTables.min.css">
 <script src="https://cdn.datatables.net/1.10.13/js/jquery.dataTables.min.js"></script>
 <script>

--- a/general-info/venues/dinner.html
+++ b/general-info/venues/dinner.html
@@ -11,7 +11,7 @@
       </p>
 
       <h3>Transportation</h3>
-      <p>Attendees must arrange for their own transportation to the restaurants. 
+      <p>Attendees must arrange for their own transportation to the restaurants.
       {% if site.data.conf.newcomer-dinner.activities-info != '' %}
               To get a sense of the locations and neighborhoods, you can check out the
               <a target="blank" href="{{site.data.conf.newcomer-dinner.activities-info}}">Activities Map</a>.
@@ -43,7 +43,7 @@
                 {% for restaurant in site.data.dinner %}
                 <tr>
                     <td>
-                      {% if restaurant.url != 'n/a' %}
+                      {% if restaurant.url != nil %}
                         <a href="{{restaurant.url}}">{{ restaurant.restaurant-name }}</a>
                       {% else %}
                         {{ restaurant.restaurant-name }}

--- a/general-info/venues/dinner.html
+++ b/general-info/venues/dinner.html
@@ -49,7 +49,7 @@
                         {{ restaurant.restaurant-name }}
                       {% endif %}
                       {% if restaurant.accessibility-and-notes %}
-                        <i tabindex="0" class="fas fa-question-circle fa-sm" data-toggle="tooltip" title="{{ restaurant.accessibility-and-notes }}"></i>
+                        <i tabindex="0" role="tooltip" class="fas fa-question-circle fa-sm" title="{{ restaurant.accessibility-and-notes | smartify }}"></i>
                       {% endif %}
                     </td>
                     <td>{{ restaurant.type-of-food }}</td>

--- a/general-info/venues/dinner.html
+++ b/general-info/venues/dinner.html
@@ -34,9 +34,9 @@
                     <th width="20%">Name</th>
                     <th>Type</th>
                     <th>Distance</th>
+                    <th>Price Point</th>
                     <th>Takes<br/>Reservations?</th>
-                    <th>Vegetarian<br/>Friendly?</th>
-                    <th>Vegan<br/>Friendly?</th>
+                    <th>Vegetarian or<br/>Vegan Friendly?</th>
                 </tr>
             </thead>
             <tbody>
@@ -48,15 +48,15 @@
                       {% else %}
                         {{ restaurant.restaurant-name }}
                       {% endif %}
-                        {% if restaurant.notes or restaurant.accessibility-notes %}
-                         <i tabindex="0" class="fas fa-question-circle fa-sm" data-toggle="tooltip" title="{{ restaurant.notes }} {{ restaurant.accessibility-notes }}"></i>
-                        {% endif %}
+                      {% if restaurant.accessibility-and-notes %}
+                        <i tabindex="0" class="fas fa-question-circle fa-sm" data-toggle="tooltip" title="{{ restaurant.accessibility-and-notes }}"></i>
+                      {% endif %}
                     </td>
                     <td>{{ restaurant.type-of-food }}</td>
                     <td>{{ restaurant.distance-from-hotel }}</td>
+                    <td>{{ restaurant.price-point }}</td>
                     <td>{% if restaurant.takes-reservations == true %}Yes{% else %}No{% endif %}</td>
-                    <td>{% if restaurant.vegetarian-options == true %}Yes{% else %}No{% endif %}</td>
-                    <td>{% if restaurant.vegan-options == true %}Yes{% else %}No{% endif %}</td>
+                    <td>{% if restaurant.vegetarian-options and restaurant.vegan-options %}Vegetarian & Vegan{% elsif restaurant.vegetarian-options %}Vegetarian{% elsif restaurant.vegan-options %}Vegan{% else %}No{% endif %}</td>
                 </tr>
                 {% endfor %}
             </tbody>


### PR DESCRIPTION
Closes #105. Mostly stops unneeded JS from being loaded but also contains a couple small improvements to newcomer dinner code & more example restaurant data. Very low priority.

**To test**:
- copy _data/examples/dinner.yml into the _data directory
- uncomment the menu items in general-info/venues/index.html 
- check that the **Restaurant List** under the Newcomer Dinner section works & makes sense http://127.0.0.1:4000/general-info/venues/#dinner

It's probably easiest to uncomment _all_ the Venues menu items. Jekyll threw an error when I uncommented only the Newcomer Dinner section, it doesn't like it if you uncomment items in the middle of an array it seems.