### PR TITLE
big set of registration, location, & general info content updates

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -76,14 +76,16 @@ venue:
   directions: 'https://medicine.buffalo.edu/about/our_campuses.html#title-1'
   a11y: ''
   hotel:
-    show: false
-    name: 'DEFAULT'
+    show: true
+    multiple-hotels: true
+    multiple-hotels-map: https://www.google.com/maps/d/u/0/viewer?mid=1NVNeQvh5brzIyWVk3iDpAkk_q5dLTOtX&ll=42.8963212217323%2C-78.870584222229&z=15
+    name:
     reserved-room-block: false
-    cost: 'DEFAULT'
-    with-tax-cost: 'DEFAULT'
+    cost:
+    with-tax-cost:
     cost-cutoff-date: 2140-12-31
-    check-in-time: 'DEFAULT'
-    check-out-time: 'DEFAULT'
+    check-in-time:
+    check-out-time:
     self-parking-fee:
     valet-parking-fee:
 
@@ -139,8 +141,8 @@ slide-template:
   url: '/assets/C4L2021-template.pptx'
 
 closed-captioning:
-  url: 'https://2021archive.1capapp.com/event/cod4lib/'
-  show: false
+  url:
+  show: true
 
 # Peri display descriptions and titles
 peri:

--- a/_data/examples/locations.yml
+++ b/_data/examples/locations.yml
@@ -1,6 +1,7 @@
 - id: law-school-building
   name: 'CUA Campus - Law School Building'
   google_maps: 'https://goo.gl/maps/tbmqSZkDPjK2'
+  # only provide a URL, we make our own responsive iframe around it
   embed_code: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d617.2297252329815!2d-76.99683608900858!3d38.93622744922624!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7c7e8639965ed%3A0xf3b10f49d85b2e9b!2sColumbus+School+of+Law+The+Catholic+University+of+America!5e0!3m2!1sen!2sus!4v1517346573765'
 - id: pryzbyla-center
   name: 'CUA Campus - Pryzbyla Center 321'

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -1,0 +1,5 @@
+- id: hayes-hall
+  name: 'Hayes Hall, University at Buffalo'
+  google_maps: 'https://goo.gl/maps/cBFP9HQXd1b5ARJh6'
+  # only provide a URL, we make our own responsive iframe around it
+  embed_code: https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d46706.20418019159!2d-78.83873112390165!3d42.97537161235213!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89d373b012ee45ab%3A0x18223823e83f3757!2sHayes%20Hall%20-%20University%20at%20Buffalo!5e0!3m2!1sen!2sus!4v1645743773341!5m2!1sen!2sus

--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -4,32 +4,43 @@
 
 # include "$" in all "cost" strings, makes templates cleaner
 
+conference:
+  # "show" means display information on the home page and /general-info/attend
+  show: true
+  url: nil
+  start-date: 2022-03-01
+  end-date: 2022-05-02
+  cancellation-date: 2022-05-02
+  # "open" means people can register
+  open: false
+  cost: "$195"
+  late-cost: "$250"
+  workshop-half-day-cost: "$40"
+  workshop-full-day-cost: "$80"
+  limited-capacity: true
+
 workshop-only:
   # "show" only affects a button on the general-info/attend page
   show: false
   url:
   # precon-only registration cost may differ from precons with general registration
-  half-day-cost: "$60"
-  full-day-cost: "$120"
-  start-date: 2022-02-11
+  half-day-cost: "$40"
+  full-day-cost: "$80"
+  start-date: 2022-03-01
 
-conference:
-  # "show" means display information on the home page and /general-info/attend
-  show: false
-  url: "https://na.eventscloud.com/c4l20"
-  start-date: 2022-12-11
-  end-date: 2022-02-10
-  cancellation-date: 2022-02-12
-  # "open" means people can register
-  open: false
-  cost: "$375"
-  late-cost: "$450"
-  workshop-half-day-cost: "$50"
-  workshop-full-day-cost: "$100"
+t-shirt-only:
+  show: true
+  start-date: 2022-03-01
+  cost: $29
+  late-date: 2022-05-03
+  late-cost: $39
 
 childcare:
   # "show" toggles the child care entry on /general-info/attend, under 'Additional Information' heading
   show: false
+  # distinct from `show: false` in that we _know_ we won't be able to offer childcare
+  no-childcare: true
+  no-childcare-text: "Child Care will, unfortunately, not be available in 2022 due to Covid-19 campus policies."
   full-day-cost: "$30"
   half-day-cost: "$15"
   end-date: 2022-02-08

--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -22,6 +22,8 @@ conference:
 workshop-only:
   # "show" only affects a button on the general-info/attend page
   show: false
+  undecided: true
+  undecided-text: "Depending on availability, Pre-Conference ONLY registration may open at the beginning of May."
   url:
   # precon-only registration cost may differ from precons with general registration
   half-day-cost: "$40"

--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -78,19 +78,19 @@
                 <br>
             {% endif %}
 
-            {% comment %}
-            {% if page.type == 'workshop' %}
+            {% if page.type == 'workshop' and page.location != nil %}
             <div class="col-12 col-sm-8 col-md-9">
                 <h2>Location</h2>
-                <div style="margin: auto; max-width: 600px;" class="embed-responsive embed-responsive-4by3">
+                <div style="margin: auto auto 1em; max-width: 600px;" class="embed-responsive embed-responsive-4by3">
                     <iframe title="workshop location" src="{{ location.embed_code }}"></iframe>
                 </div>
-                <p class="text-center">
-                    <a class="btn ct-btn-light" href="{{ location.floor_plan }}" target="_blank">Floor Plan</a>
-                </p>
+                {% if location.floor_plan != nil %}
+                    <p class="text-center">
+                        <a class="btn ct-btn-light" href="{{ location.floor_plan }}" target="_blank">Floor Plan</a>
+                    </p>
+                {% endif %}
             </div>
             {% endif %}
-            {% endcomment %}
         </div>
         <div class="col-12 col-sm-4 col-md-3 text-center">
             <div class="row talk-detail-box">
@@ -123,15 +123,15 @@
                 </div>
                 {% endif %}
 
-                <!-- building for workshops -->
+                <!-- building for in-person workshops -->
                 {% if page.type == 'workshop' %}
                 <div class="col-12 col-sm-12 col-md-12 time-length">
-                    <!--
-                    <div class="talk-box-detail-icon"><span class="glyphicon glyphicon-map-marker"></span></div>
-                    <div class="talk-box-detail-value">
-                        {{ location_display }}
-                    </div>
-                    -->
+                    {% if location != nil %}
+                        <div class="talk-box-detail-icon"><span class="glyphicon glyphicon-map-marker"></span></div>
+                        <div class="talk-box-detail-value">
+                            {{ location_display }}
+                        </div>
+                    {% endif %}
                     <div>
                         <a class="back-workshops" href="/workshops">⇦ Return to Workshop List</a>
                     </div>

--- a/_posts/2022-05-23-Belt-and-Suspenders-Crafting-Full-Coverage-Monitoring-for-Library-Applications.md
+++ b/_posts/2022-05-23-Belt-and-Suspenders-Crafting-Full-Coverage-Monitoring-for-Library-Applications.md
@@ -9,8 +9,8 @@ max-attendees: 24
 startTime: 1:30pm
 endTime: 4:30pm
 time: pm
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - francis-kayiwa
 - alicia-cozine
@@ -21,6 +21,6 @@ title: Belt and Suspenders&#58; Crafting Full Coverage Monitoring for Library Ap
 ---
 We use the term "monitoring" to describe a collection of components that make up a system comprised of fault detection, metric collection, analytics, visualization, and notification. We will talk about our composable system, with modular design, combining several tools to fulfill the functions of each component.
 
-We will look at how we use Sensu, an open source monitoring tool designed for today’s systems and Datadog (we will address budget neutral alternatives). Sensu is commonly referred to as "the monitoring framework," allowing its users to compose a monitoring system to meet their unique demands. Sensu provides a monitoring agent, transport, event processor, HTTP API, etc.  Datadog is an extensive, easy-to-use platform for understanding your infrastructure. 
+We will look at how we use Sensu, an open source monitoring tool designed for today’s systems and Datadog (we will address budget neutral alternatives). Sensu is commonly referred to as "the monitoring framework," allowing its users to compose a monitoring system to meet their unique demands. Sensu provides a monitoring agent, transport, event processor, HTTP API, etc.  Datadog is an extensive, easy-to-use platform for understanding your infrastructure.
 
 In this presentation, we will discuss each component of a modern monitoring system, comparing several approaches to each of them. We will also cover the advantages and disadvantages of specific tool architectures, talk about Sensu and Datadigs approach to monitoring.

--- a/_posts/2022-05-23-Fail4Lib-X.md
+++ b/_posts/2022-05-23-Fail4Lib-X.md
@@ -4,13 +4,13 @@ type: workshop
 categories: workshops
 full: false
 learning-outcomes: Participants will leave this session more comfortable with failing and more comfortable with discussing failure openly. Participants will learn strategies for making failure more productive and valuable, and for making their organizations more willing to embrace failure as a learning opportunity.
-attendee-requirements: 
+attendee-requirements:
 max-attendees: 25
 startTime: 1:30pm
 endTime: 4:30pm
 time: pm
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - andreas-orphanides
 speaker-text: Andreas Orphanides

--- a/_posts/2022-05-23-Getting-the-most-out-of-Wikibase4Lib.md
+++ b/_posts/2022-05-23-Getting-the-most-out-of-Wikibase4Lib.md
@@ -9,8 +9,8 @@ max-attendees: 15
 startTime: 9:00am
 endtime: 12:00pm
 time: am
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - timothy-ryan-mendenhall
 - jim-hahn
@@ -18,8 +18,8 @@ speakers:
 speaker-text: Timothy Ryan Mendenhall, Jim Hahn, Esther Jackson
 title: Getting the most out of Wikibase4Lib
 ---
-This three hour session will provide an introduction to getting Wikibase, the software that powers Wikidata, configured on your local machine by way of Docker Desktop. The session includes an accessible and newbie friendly introduction to using Docker on your laptop, followed by a necessary (though not overly technical) delineation of the unique technology stack that makes up the Wikibase linked data system. 
+This three hour session will provide an introduction to getting Wikibase, the software that powers Wikidata, configured on your local machine by way of Docker Desktop. The session includes an accessible and newbie friendly introduction to using Docker on your laptop, followed by a necessary (though not overly technical) delineation of the unique technology stack that makes up the Wikibase linked data system.
 
-After we have walked through the Wikibase installation steps, we will provide an overview of features and functionality of a local Wikibase. The following configuration tasks will be covered: account management features -- including adding users; importing items and properties from Wikidata; a demonstration of configuring and using the Wikibase query service; using OpenRefine with arbitrary Wikibase installs; recent advances in federated property use by the Wikibase ecosystem. This session will make use of the latest Wikibase Docker install documentation: Wikibase/Docker - MediaWiki. 
+After we have walked through the Wikibase installation steps, we will provide an overview of features and functionality of a local Wikibase. The following configuration tasks will be covered: account management features -- including adding users; importing items and properties from Wikidata; a demonstration of configuring and using the Wikibase query service; using OpenRefine with arbitrary Wikibase installs; recent advances in federated property use by the Wikibase ecosystem. This session will make use of the latest Wikibase Docker install documentation: Wikibase/Docker - MediaWiki.
 
 The final hour of the workshop will be reserved for independent work, question and answer time, and general troubleshooting for your newly installed Wikibase instance!

--- a/_posts/2022-05-23-Including-and-Unleashing-Everyone-Facilitation-with-Liberating-Structures.md
+++ b/_posts/2022-05-23-Including-and-Unleashing-Everyone-Facilitation-with-Liberating-Structures.md
@@ -9,8 +9,8 @@ max-attendees: 25
 startTime: 9:00am
 endTime: 12:00pm
 time: am
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - mark-a-matienzo
 - hillel-arnold

--- a/_posts/2022-05-23-Introduction-to-Figma.md
+++ b/_posts/2022-05-23-Introduction-to-Figma.md
@@ -4,13 +4,13 @@ type: workshop
 categories: workshops
 full: false
 learning-outcomes: Figma 101. What Figma is, why you would want to use it, and how to integrate it into the current workflow.
-attendee-requirements: 
+attendee-requirements:
 max-attendees: 20
 startTime: 1:30pm
 endTime: 4:30pm
 time: pm
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - axa-liauw
 - dianne-weinthal

--- a/_posts/2022-05-23-Modern-Alchemy-Turning-data-into-information.md
+++ b/_posts/2022-05-23-Modern-Alchemy-Turning-data-into-information.md
@@ -9,8 +9,8 @@ max-attendees: 12
 startTime: 1:30pm
 endTime: 4:30pm
 time: pm
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - eric-morgan
 speaker-text: Eric Morgan

--- a/_posts/2022-05-23-Power-of-Extensibility-Building-custom-apps-for-the-Library-System.md
+++ b/_posts/2022-05-23-Power-of-Extensibility-Building-custom-apps-for-the-Library-System.md
@@ -9,13 +9,13 @@ max-attendees: 50
 startTime: 9:00am
 endTime: 12:00pm
 time: am
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - josh-weisman
 speaker-text: Josh Weisman
 title: Power of Extensibility&#58; Building custom apps for the Library System
 ---
-The Alma library system now supports an extensibility framework called Cloud Apps. This allows the community to build apps which integrate directly with Alma to provide custom functionality for users. Apps can be shared with other institutions in an app store-style repository. 
+The Alma library system now supports an extensibility framework called Cloud Apps. This allows the community to build apps which integrate directly with Alma to provide custom functionality for users. Apps can be shared with other institutions in an app store-style repository.
 
 In this session, we'll build a Cloud App using a local SDK powered by Angular, TypeScript, REST APIs, and Material Design components. This session will provide a great hands-on introduction to developing client-side apps in Angular. Developers from libraries that don't use Alma can take the skills they've learned to their next project. Libraries that use Alma will be well poised to build their own Cloud Apps which answer their users' requirements.

--- a/_posts/2022-05-23-Understanding-Drupal-and-why-you-should.md
+++ b/_posts/2022-05-23-Understanding-Drupal-and-why-you-should.md
@@ -9,8 +9,8 @@ max-attendees: 20
 startTime: 9:00am
 endTime: 12:00pm
 time: am
-location: 
-room: 
+location: hayes-hall
+room:
 speakers:
 - cary-gordon
 speaker-text: Cary Gordon

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -209,16 +209,14 @@ active: Attend Code4Lib
                 {% if site.data.conf.closed-captioning.show %}
                 {% assign sponsors = site.data.sponsors | where:"transcription","true" %}
                 <h3>Live Transcription</h3>
+                {% if site.data.conf.closed-captioning.url != nil %}
                 <p>
-                    We are thrilled to be able to provide
-                    {% if site.data.conf.closed-captioning.url != nil %}
-                        <a href="{{ site.data.conf.closed-captioning.url }}">
-                    {% endif %}
-                        live transcriptions of all the presentations
-                    {% if site.data.conf.closed-captioning.url != nil %}</a>{% endif %}.
-                    {% if site.data.conf.closed-captioning.url == nil %}
-                        A link to view the transcriptions will be added here in the days leading up to the conference.
-                    {% endif %}
+                    We are thrilled to be able to provide <a href="{{ site.data.conf.closed-captioning.url }}">
+                    live transcriptions of all the presentations</a>.
+                {% else %}
+                    We are thrilled to be able to provide live transcriptions of all the presentations.
+                {% endif %}
+                    A link to view the transcriptions will be added here in the days leading up to the conference.
                 </p>
                 {% if sponsors.size > 0 %}
                     <p>

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -153,6 +153,12 @@ active: Attend Code4Lib
                             to register for the conference at full price.
                         {% endif %}
                     </li>
+
+                    {% if site.data.registration.workshop-only.undecided %}
+                        <li>
+                            {{ site.data.registration.workshop-only.undecided-text }}
+                        </li>
+                    {% endif %}
                 </ol>
             </div>
         </div>

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -71,7 +71,9 @@ active: Attend Code4Lib
                         <li><span class="font-weight-bold">Reception "plus one"</span>: {{ site.data.registration.reception.plus-one-cost }} (limit one "plus one" per registration)</li>
                     {% endif %}
 
-                    {% if site.data.conf.online-only-conference == false and site.data.conf.venue.hotel.show %}
+                    {% if site.data.conf.online-only-conference == false
+                        and site.data.conf.venue.hotel.show
+                        and site.data.conf.venue.hotel.multiple-hotels == false %}
                     <li>
                         <span class="font-weight-bold">{{site.data.conf.venue.hotel.name}}</span>:
                         {{ site.data.conf.venue.hotel.cost }}/night
@@ -82,6 +84,10 @@ active: Attend Code4Lib
                         {% if site.data.conf.venue.hotel.cost-cutoff-date %}
                             until {{ site.data.conf.venue.hotel.cost-cutoff-date | date: "%B %-d" }}
                         {% endif %}
+                    </li>
+                    {% else %}
+                    <li>
+                        <span class="font-weight-bold">Lodging</span>:The Local Planning Committee has put together <a href="{{ site.data.conf.venue.hotel.multiple-hotels-map }}">a Google Map with pins</a> to help you find lodging in the area around the {{ site.data.conf.venue.name }}.
                     </li>
                     {% endif %}
                 </ul>

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -14,13 +14,16 @@ active: Attend Code4Lib
                         {% if site.data.registration.conference.open %}
                             <a href="{{ site.data.registration.conference.url }}" class="btn ct-btn-light btn-lg">Register Now!</a>
                         {% else %}
-                            <p>Registration will open at 12 p.m. EST / 9 a.m. PST on <span class="font-weight-bold">{{ site.data.registration.conference.start-date | date: '%A, %B %-d, %Y' }}</span>.</p>
+                            <p>Registration will open
+                                at 11 a.m. EST / 8 a.m. PST
+                                on <span class="font-weight-bold">{{ site.data.registration.conference.start-date | date: '%A, %B %-d, %Y' }}</span>.</p>
                         {% endif %}
                     {% else %}
                         <p>Code4Lib will be held from {{site.data.conf.days[0].date}} to {{site.data.conf.days.last.date}} this year.
                             {% if site.data.conf.venue.hotel.reserved-room-block %}
                             We have reserved a block at the {{site.data.conf.venue.hotel.name}}; see more details on the <a href="venues/">Venues</a> page.
                             {% endif %}
+                            There will be no large group block of rooms at a single hotel this year, but the Local Planning Committee is looking into discounted room rates at a few nearby hotels. See <a href="/general-info/venues/">Venues</a> page for more information.
                         </p>
                     {% endif %}
 
@@ -40,7 +43,6 @@ active: Attend Code4Lib
 
                     <li><span class="font-weight-bold">Main Conference (after {{ site.data.registration.conference.end-date | date: "%B %-d" }})</span>: {{ site.data.registration.conference.late-cost }}</li>
 
-
                     {% if site.data.registration.post-conference.show %}
                         {% if site.data.registration.post-conference.workshop-half-day-cost %}
                             <li><span class="font-weight-bold">Post-Conference</span>: {{ site.data.registration.post-conference.workshop-half-day-cost }} per workshop</li>
@@ -50,7 +52,18 @@ active: Attend Code4Lib
                     {% else %}
                         <li><span class="font-weight-bold">Pre-Conferences (with main conference registration)</span>: {{ site.data.registration.conference.workshop-half-day-cost }} per half day ({{ site.data.registration.conference.workshop-full-day-cost }} for full day)</li>
 
-                        <li><span class="font-weight-bold">Pre-Conference Only</span>: {{ site.data.registration.workshop-only.half-day-cost }} per half day ({{ site.data.registration.workshop-only.full-day-cost }} for full day) {%- if site.data.registration.workshop-only.start-date -%}. Opens {{ site.data.registration.workshop-only.start-date | date: "%B %-d" }}.{%- endif -%}</li>
+                        {% if site.data.registration.workshop-only.show %}
+                            <li><span class="font-weight-bold">Pre-Conference Only</span>: {{ site.data.registration.workshop-only.half-day-cost }} per half day ({{ site.data.registration.workshop-only.full-day-cost }} for full day) {%- if site.data.registration.workshop-only.start-date -%}. Opens {{ site.data.registration.workshop-only.start-date | date: "%B %-d" }}.{%- endif -%}</li>
+                        {% endif %}
+                    {% endif %}
+
+                    {% if site.data.registration.t-shirt-only.show %}
+                        <li><span class="font-weight-bold">Conference T-Shirt ONLY</span>: {{ site.data.registration.t-shirt-only.cost }}.
+                        {% if site.data.registration.t-shirt-only.late-cost != nil %}
+                            {{ site.data.registration.t-shirt-only.late-cost }} on or after
+                            {{ site.data.registration.t-shirt-only.late-date | date: "%B %-d" }}
+                        {% endif %}
+                        </li>
                     {% endif %}
 
 
@@ -58,7 +71,7 @@ active: Attend Code4Lib
                         <li><span class="font-weight-bold">Reception "plus one"</span>: {{ site.data.registration.reception.plus-one-cost }} (limit one "plus one" per registration)</li>
                     {% endif %}
 
-                    {% if site.data.conf.online-only-conference == false %}
+                    {% if site.data.conf.online-only-conference == false and site.data.conf.venue.hotel.show %}
                     <li>
                         <span class="font-weight-bold">{{site.data.conf.venue.hotel.name}}</span>:
                         {{ site.data.conf.venue.hotel.cost }}/night
@@ -78,16 +91,24 @@ active: Attend Code4Lib
                 </p>
 
                 <p>
-                    <span class="font-weight-bold">Cancellation Policy</span>: Refunds will not be issued this year (except in extenuating circumstances). Registrants are able to transfer completed registrations to colleagues - please contact <a href="mailto:{{ site.data.conf.main-conf-email }}">{{ site.data.conf.main-conf-email }}</a> to finalize this process.
+                    <span class="font-weight-bold">Cancellation Policy</span>: All cancellations received on or before {{ site.data.registration.conference.cancellation-date | date: "%B %-d, %Y" }} are eligible for a full refund of fees paid, less a 10% cancellation fee. No refunds will be issued after the {{ site.data.registration.conference.cancellation-date | date: "%B %-d" }} cut-off date. Registrants are able to transfer completed registrations to colleagues - please contact <a href="mailto:{{ site.data.conf.main-conf-email }}">{{ site.data.conf.main-conf-email }}</a> to finalize this process.
                 </p>
 
+                {%- comment -%}
                 <p>
                     When you register, you will be able to select two half-day workshops. As with past Code4Lib conferences, it will be possible to register for the main conference, the main conference + post-conference(s), or only for the post-conference workshop(s)
                 </p>
                 <p>
                     <span class="font-weight-bold">Post-conference only registration will not open this year due to limited sessions and capacity.</span>
                 </p>
+                {%- endcomment -%}
+            </div>
+        </div>
 
+        <div class="row">
+            <div class="col-12">
+                <h3>Health & Wellness</h3>
+                <p>Because Code4Lib is taking place on the Downtown Campus of the University at Buffalo, all attendees must adhere to the university's Guidelines for Visitors. These guidelines often change as the COVID-19 public health crisis evolves, and we strongly suggest you check that page frequently leading up to the conference.</p>
             </div>
         </div>
 
@@ -102,6 +123,10 @@ active: Attend Code4Lib
                           <span class="font-weight-bold">Please Note</span>: Child Care Registration will close on {{ site.data.registration.childcare.end-date | date: "%B %e, %Y" }}. Registration and payment must be finalized on or before {{ site.data.registration.childcare.end-date | date: "%B %e"}}, to utilize the child care services.
                         {% endif %}
                     </li>
+                    {% elsif site.data.registration.childcare.no-childcare %}
+                        <li>
+                            {{ site.data.registration.childcare.no-childcare-text }}
+                        </li>
                     {% endif %}
 
                     {% if site.data.registration.conference.limited-capacity %}
@@ -141,18 +166,30 @@ active: Attend Code4Lib
     <div class="container-fluid">
         <div class="row">
             <div class="col-12">
-                <h2>Can't attend the live stream?</h2>
-                {% if site.data.registration.conference.open %}
+                {% if site.data.conf.online-only-conference %}
+                    <h2>Can't attend the live stream?</h2>
+                {% else %}
+                    <h2>Can't attend in person?</h2>
+                {% endif %}
+
+                {% if site.data.conf.online-only-conference and site.data.registration.conference.open %}
                     <p>
                         Due to the conference being virtual this year, we will not be Live Streaming the sessions on YouTube. If you are interested in participating in real-time, you must <a href="{{ site.data.registration.conference.url }}">register</a> for the event to receive the information and access to the live streams.
                     </p>
                 {% endif %}
 
-                <h3>Archive</h3>
                 <p>
-                    Presentations will be archived on our <a href="{{ site.data.conf.social-links.youtube}}">YouTube channel</a> after the conference has ended.
+                    Presentations will be
+                    {% unless site.data.conf.online-only-conference %}streamed and{% endunless %}
+                    archived on our <a href="{{ site.data.conf.social-links.youtube }}">YouTube channel</a> after the conference has ended.
                     Please be sure to thank our volunteers that make this happen.
                 </p>
+
+                <p>For 2022, there are two options for participating remotely.</p>
+                <ul>
+                    <li><span class="font-weight-bold">Option 1</span> - Watch the presentations streamed to the code4lib YouTube channel and subscribe to the #code4libcon Slack channel to engage in discussions with all attendees during the conference. There is no fee for this option.</li>
+                    <li><span class="font-weight-bold">Option 2</span> - Register online as a “Conference T-Shirt ONLY Attendee”, pay the appropriate registration fee based on your registration date (see above for fees), and receive the same conference t-shirt that in-person attendees receive. If you choose this registration type, you'll watch and engage in the conference in the same manner as outlined in Option 1, above. NOTE: “Conference T-Shirt ONLY Attendee” registration is NOT required to participate in the conference, as outlined in Option 1 above.</li>
+                </ul>
 
                 <h3>Social Media and "Back Channels"</h3>
                 <p>
@@ -168,11 +205,14 @@ active: Attend Code4Lib
                 <h3>Live Transcription</h3>
                 <p>
                     We are thrilled to be able to provide
-                    {% if site.data.conf.closed-captioning.show %}
-                        <a href="{{site.data.conf.closed-captioning.url}}">
+                    {% if site.data.conf.closed-captioning.url != nil %}
+                        <a href="{{ site.data.conf.closed-captioning.url }}">
                     {% endif %}
                         live transcriptions of all the presentations
-                    {% if site.data.conf.closed-captioning.show %}</a>{% endif %}.
+                    {% if site.data.conf.closed-captioning.url != nil %}</a>{% endif %}.
+                    {% if site.data.conf.closed-captioning.url == nil %}
+                        A link to view the transcriptions will be added here in the days leading up to the conference.
+                    {% endif %}
                 </p>
                 {% if sponsors.size > 0 %}
                     <p>

--- a/general-info/venues/hotel.html
+++ b/general-info/venues/hotel.html
@@ -41,14 +41,31 @@
             Rooms may be available at the group rate before or after the above dates, based on availability at the hotel.
             While the reservation will require a credit card, it will not be charged until you arrive (you may also incur a fee if you do not show, or cancel outside of the allowable cancellation time frame).
         </p>
-        {% else %}
+        {% elsif site.data.conf.venue.hotel.name != nil %}
         <p>
-            The conference hotel is the {{site.data.conf.venue.hotel.name}}. While the reservation will require a credit card, it will not be charged until you arrive (you may also incur a fee if you do not show, or cancel outside of the allowable cancellation time frame).
+            The conference hotel is the {{ site.data.conf.venue.hotel.name }}. While the reservation will require a credit card, it will not be charged until you arrive (you may also incur a fee if you do not show, or cancel outside of the allowable cancellation time frame).
         </p>
         {% endif %}
+        {% if site.data.conf.venue.hotel.check-in-time %}
         <p>
-            Check-in is at {{site.data.conf.venue.hotel.check-in-time}} while check-out is {{site.data.conf.venue.hotel.check-out-time}}. Included in our reservation is free access to the hotel's guest WiFi network.
+            Check-in is at {{site.data.conf.venue.hotel.check-in-time}} while check-out is
+            {{site.data.conf.venue.hotel.check-out-time}}. Included in our reservation is free access to the hotel's guest WiFi
+            network.
         </p>
+        {% endif %}
+
+        {% if site.data.conf.venue.hotel.multiple-hotels %}
+            <p>
+                Due to the nature of hosting this conference on campus, in {{ site.data.conf.year }} there will not be a centralized hotel location.
+                The Local Planning Committee is looking into small blocks of rooms at nearby hotels where we hope to secure rooms at modestly discounted rates.
+                Check back for more information, which will be added here as it becomes available.
+            </p>
+            {% if site.data.conf.venue.hotel.multiple-hotels-map %}
+                <p>
+                    The conference Local Planning Committee has put together <a href="{{ site.data.conf.venue.hotel.multiple-hotels-map }}">a Google Map</a> with pins to help you find lodging in the area around the {{ site.data.conf.venue.name }} building, site of the main conference.
+                </p>
+            {% endif %}
+        {% endif %}
 
         {% if site.data.conf.venue.hotel.self-parking-fee or site.data.conf.venue.hotel.valet-parking-fee %}
             <h3>Parking</h3>
@@ -61,4 +78,11 @@
         {% endif %}
     </div>
     {% endif %}
+
+    <div class="col-12">
+        <h3>Transportation</h3>
+        <p>
+            For information regarding local public transit options, driving directions, and parking availability, please consult the Jacobs School Facilities Planning and Management <a href="https://medicine.buffalo.edu/offices/facilities/parking.html">"Commuting" help page</a>.
+        </p>
+    </div>
 </section>

--- a/general-info/venues/index.html
+++ b/general-info/venues/index.html
@@ -10,9 +10,9 @@ subnav:
 - name: Workshops
   include: workshops.html
   url: '#workshops'
-#- name: Reception
-#  include: reception.html
-#  url: '#reception'
+- name: Reception
+  include: reception.html
+  url: '#reception'
 #- name: Accommodations
 #  include: accommodations.html
 #  url: '#accommodations'

--- a/general-info/venues/reception.html
+++ b/general-info/venues/reception.html
@@ -3,45 +3,64 @@
     <div class="col-12">
         <h2 id="reception">Reception</h2>
 
-        <h3>{{site.data.conf.reception.venue}}</h3>
-        <div class="row">
-            <div class="col-6">
-                <a href="{{site.data.conf.reception.url}}">
-                    <img src="/assets/img/venues/{{site.data.conf.reception.image}}" class="img-fluid" title="{{site.data.conf.reception.image_title}}" alt="{{site.data.conf.reception.image_alt}}"></a>
+        {% unless site.data.conf.reception.venue.show %}
+            Stay tuned… When the location and timing of the conference reception is confirmed, the details will be added here.
+        {% else %}
+
+            <h3>{{ site.data.conf.reception.venue }}</h3>
+            <div class="row">
+                <div class="col-6">
+                    <a href="{{site.data.conf.reception.url}}">
+                        <img src="/assets/img/venues/{{site.data.conf.reception.image}}" class="img-fluid"
+                            title="{{site.data.conf.reception.image_title}}" alt="{{site.data.conf.reception.image_alt}}"></a>
+                </div>
+                <div class="col-6">
+                    <p>
+                        {{site.data.conf.reception.venue}}<br />
+                        {{site.data.conf.reception.street}}<br />
+                        {{site.data.conf.city-state}} {{site.data.conf.reception.postal-code}}<br />
+                        <a href="tel:{{site.data.conf.reception.phone}}">{{site.data.conf.reception.phone}}</a> or <a
+                            href="mailto:{{site.data.conf.reception.contact}}">email</a>{% if site.data.conf.reception.floorplan %}
+                        | <a href="{{site.data.conf.reception.floorplan}}">Floor Plan</a> {% endif %}<br />
+                        <a href="https://cmoa.org/visit/directions/">Visiting the Museum</a>
+                    </p>
+                </div>
             </div>
-            <div class="col-6">
+
+            <div class="col-12">
+                <h3>Directions</h3>
+                <p><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> <strong>Don't forget your
+                        conference name tag and lanyard!</strong></p>
+                <p>Shuttle services travelling from the hotel to the reception will be available for attendees.
+                    <!--, starting at 6:15 PM. They will pick up outside the hotel's Convention Entrance—the entrance directly in front of the conference registration area.-->
+                    Buses will loop between the museum and hotel for the duration of the reception.
+                    <!--, with the last one leaving the museum at 8:40 PM after the reception has ended.-->
+                </p>
+                <h4>Transit</h4>
+                <p><strong>Using plain words</strong>: From the Westin Pittsburgh, walk 0.3 miles south towards Fifth Avenue at
+                    Smithfield Street. Take the 61C bus 20 stops to Forbes Avenue at Bellefield Avenue South. Walk 0.2 miles east to
+                    the Carnegie Museum of Pittsburgh. Estimated travel time is roughly 29 minutes.
+                </p>
+                <p><strong>Using technology</strong>:</p>
+                <div style="margin: auto; max-width: 800px;" class="embed-responsive embed-responsive-4by3">
+                    <iframe title="Google Maps"
+                        src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d7799.3451841782335!2d-79.99012088186703!3d40.43947143734802!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e3!4m5!1s0x8834f3e280b3ce5f%3A0x69e7db8e16c9758b!2sWestin%20Convention%20Center%20of%20Pittsburgh%2C%20Penn%20Avenue%2C%20Pittsburgh%2C%20PA!3m2!1d40.4442902!2d-79.9948067!4m5!1s0x8834f2265ce2f431%3A0x63cb21fe069ffa76!2sCarnegie%20Museum%20of%20Pittsburgh%2C%20Forbes%20Avenue%2C%20Art%2C%20PA!3m2!1d40.4437052!2d-79.9489727!5e0!3m2!1sen!2sus!4v1568665689793!5m2!1sen!2sus"
+                        width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
+                </div>
+            </div>
+
+            <div class="col-12">
+                <h3>Reception Details</h3>
+
+                <p><strong>When: </strong>
+                    {{site.data.conf.reception.date | date: '%A, %B %-d, %Y'}} from 6:30pm-8:30pm
+                </p>
                 <p>
-                    {{site.data.conf.reception.venue}}<br />
-                    {{site.data.conf.reception.street}}<br />
-                    {{site.data.conf.city-state}} {{site.data.conf.reception.postal-code}}<br />
-                    <a href="tel:{{site.data.conf.reception.phone}}">{{site.data.conf.reception.phone}}</a> or <a href="mailto:{{site.data.conf.reception.contact}}">email</a>{% if site.data.conf.reception.floorplan %} | <a href="{{site.data.conf.reception.floorplan}}">Floor Plan</a> {% endif %}<br />
-                    <a href="https://cmoa.org/visit/directions/">Visiting the Museum</a>
+                    We will be in the Hall of Sculpture and Scaife Foyer, located on the first and second floor of the museum. Light
+                    refreshments and drinks will be provided.</p>
+                <!-- You should receive one green drink ticket when you pick up your name badge at the registration desk. -->
                 </p>
             </div>
-        </div>
-    </div>
-
-    <div class="col-12">
-        <h3>Directions</h3>
-        <p><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> <strong>Don't forget your conference name tag and lanyard!</strong></p>
-        <p>Shuttle services travelling from the hotel to the reception will be available for attendees.<!--, starting at 6:15 PM. They will pick up outside the hotel's Convention Entrance—the entrance directly in front of the conference registration area.--> Buses will loop between the museum and hotel for the duration of the reception. <!--, with the last one leaving the museum at 8:40 PM after the reception has ended.--></p>
-        <h4>Transit</h4>
-        <p><strong>Using plain words</strong>: From the Westin Pittsburgh, walk 0.3 miles south towards Fifth Avenue at Smithfield Street. Take the 61C bus 20 stops to Forbes Avenue at Bellefield Avenue South. Walk 0.2 miles east to the Carnegie Museum of Pittsburgh. Estimated travel time is roughly 29 minutes.
-        </p>
-        <p><strong>Using technology</strong>:</p>
-        <div style="margin: auto; max-width: 800px;" class="embed-responsive embed-responsive-4by3">
-            <iframe title="Google Maps" src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d7799.3451841782335!2d-79.99012088186703!3d40.43947143734802!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e3!4m5!1s0x8834f3e280b3ce5f%3A0x69e7db8e16c9758b!2sWestin%20Convention%20Center%20of%20Pittsburgh%2C%20Penn%20Avenue%2C%20Pittsburgh%2C%20PA!3m2!1d40.4442902!2d-79.9948067!4m5!1s0x8834f2265ce2f431%3A0x63cb21fe069ffa76!2sCarnegie%20Museum%20of%20Pittsburgh%2C%20Forbes%20Avenue%2C%20Art%2C%20PA!3m2!1d40.4437052!2d-79.9489727!5e0!3m2!1sen!2sus!4v1568665689793!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
-        </div>
-    </div>
-
-    <div class="col-12">
-        <h3>Reception Details</h3>
-
-        <p><strong>When: </strong>
-            {{site.data.conf.reception.date | date: '%A, %B %-d, %Y'}} from 6:30pm-8:30pm
-        </p>
-        <p>
-             We will be in the Hall of Sculpture and Scaife Foyer, located on the first and second floor of the museum. Light refreshments and drinks will be provided.</p> <!-- You should receive one green drink ticket when you pick up your name badge at the registration desk. -->
-        </p>
+        {% endunless %}
     </div>
 </section>

--- a/general-info/venues/workshops.html
+++ b/general-info/venues/workshops.html
@@ -1,6 +1,14 @@
 <section class="general-info">
     <div class="col-12">
         <h2 id="workshops">Workshops</h2>
-        <p>Workshops are typically held at several convenient locations near the conference hotel. In the past, we've used spaces at local universities and public libraries. Please <a href="/workshops/">check your workshop's location</a>.</p>
+        {%- comment -%}
+        <p>
+            Workshops are typically held at several convenient locations near the conference hotel. In the past, we've used spaces at local universities and public libraries. Please <a href="/workshops/">check your workshop's location</a>.
+        </p>
+        {%- endcomment -%}
+
+        <p>
+            All Pre-Conference workshops will be held {{ site.data.conf.days[0].weekday }}, {{ site.data.conf.days[0].date-data | date: "%B %-d, %Y" }}, in Hayes Hall at the University at Buffalo's South Campus (3435 Main St, Buffalo, NY 14214). This is an approximately 15-minute commute from the JSMBS building, via the Metro Rail and a short amount of walking. The station name for JSMBS is Allen-Medical Campus, and the station name for UB's South Campus is University Station. The Metro Rail is one line.
+        </p>
     </div>
 </section>


### PR DESCRIPTION
This changes a lot of content throughout the site. Check changes against [the google doc](https://docs.google.com/document/d/11afzReJcrW0sR-SepA2ooe0AX9fssvUL_5xr0oKq0XU/edit#) that Kathy provided. These pages are affected:

- the home page (registration notice but no link yet)
- /general-info/attend (lots of info on costs, wellness, & remote participation)
- /general-info/venues/ and its sub-sections (new lodging, transportation, workshop, & reception info)
- /workshops/ all workshops now have location info

There may be more pages that I missed. I struggled to incorporate the changes in a data-driven, future-friendly manner in a few spots. Sometimes I think it's just easier for us to edit chunks of HTML than deal with a bunch of data references.