### PR TITLE
Open: registration

### DIFF
--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -7,12 +7,12 @@
 conference:
   # "show" means display information on the home page and /general-info/attend
   show: true
-  url: nil
+  url: https://code4lib.regfox.com/code4lib-2022
   start-date: 2022-03-01
   end-date: 2022-05-02
   cancellation-date: 2022-05-02
   # "open" means people can register
-  open: false
+  open: true
   cost: "$195"
   late-cost: "$250"
   workshop-half-day-cost: "$40"


### PR DESCRIPTION
Closes #107. Registration button should show up: on home page in the blue header stripe, further down in the middle of the page, and on the general-info/attend page.

11am EST is 4pm UTC and PR Scheduler uses UTC time: https://savvytime.com/converter/utc-to-est/mar-1-2022/4pm