### PR TITLE
Remove venue image link

### DIFF
--- a/general-info/venues/hotel.html
+++ b/general-info/venues/hotel.html
@@ -6,8 +6,7 @@
 
         {% if site.data.conf.venue.image %}
         <div class="col-6">
-            <a href="{{site.data.conf.venue.website}}">
-            <img class="img-fluid" src="/assets/img/venues/{{ site.data.conf.venue.image }}" alt="{{ site.data.conf.venue.name }}"></a>
+            <img class="img-fluid" src="/assets/img/venues/{{ site.data.conf.venue.image }}" alt="{{ site.data.conf.venue.name }}">
         </div>
         {% endif %}
 


### PR DESCRIPTION
Removes the link on the venue image on the general info page. Resolves #151.