### PR TITLE
Remove timeline scrolling effect

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,35 +1,5 @@
 
 jQuery(document).ready(function($){
-    var timelineBlocks = $('.cd-timeline-block'),
-        offset = 0.8;
-
-    //hide timeline blocks which are outside the viewport
-    hideBlocks(timelineBlocks, offset);
-
-    //on scolling, show/animate timeline blocks when enter the viewport
-    $(window).on('scroll', function(){
-        if (window.requestAnimationFrame) {
-            return window.requestAnimationFrame(function(){ showBlocks(timelineBlocks, offset) });
-        }
-        return setTimeout(function(){ showBlocks(timelineBlocks, offset) }, 100)
-    });
-
-    function hideBlocks(blocks, offset) {
-        blocks.each(function(){
-            if ($(this).offset().top > $(window).scrollTop() + $(window).height() * offset) {
-                $(this).find('.cd-timeline-img, .cd-timeline-content').addClass('is-hidden')
-            }
-        });
-    }
-
-    function showBlocks(blocks, offset) {
-        blocks.each(function(){
-            if ($(this).offset().top <= $(window).scrollTop() + $(window).height() * offset &&
-                $(this).find('.cd-timeline-img').hasClass('is-hidden')) {
-                    $(this).find('.cd-timeline-img, .cd-timeline-content').removeClass('is-hidden').addClass('bounce-in')
-                }
-        });
-    }
 
     $('.sort-workshop-time').click(function(){
         console.log('sort event - time')


### PR DESCRIPTION
Removes the timeline scrolling effect on the schedule page which was causing some issues with accessibility. Resolves #149.

To test, load one of the schedule pages, navigate the page with keyboard tabbing, and ensure all links are navigated to (and that no other core functionality has been impacted).