### PR TITLE
make session title links tab accessible when bio is open

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -67,13 +67,15 @@ jQuery(document).ready(function($){
 		if($(target+'-info').hasClass('show')) {
 		    $(target+'-info').removeClass('show');
             $(target+'-id').removeClass('selected');
+            $(target+'-info .speaker-session a').attr('tabindex', -1);
 		}
         else {
             $('.speaker-info').removeClass('show');
             $('.speaker-box').removeClass('selected');
             $(target+'-info').addClass('show');
             $(target+'-id').addClass('selected');
-        } 
+            $(target+'-info .speaker-session a').removeAttr('tabindex');
+        }
 
     }
 
@@ -84,7 +86,7 @@ jQuery(document).ready(function($){
 			// this toggle is already open, so close it
 			toggle.attr('aria-expanded', 'false');
 		}
-		else { 
+		else {
 			// any other expanded bio is now closed & this one is open
 			$('.speaker-info-toggle')
 				.filter((idx, el) => $(el).attr('aria-expanded') == 'true')
@@ -131,7 +133,7 @@ jQuery(document).ready(function($){
                 i = i+2;
             }
         });
-		
+
 		infoOrder = 1,
 		i = 1,
 		ik = 1;
@@ -205,4 +207,3 @@ jQuery(document).ready(function($){
     });
 
 });
-


### PR DESCRIPTION
See #150. The linked session titles in bios are not keyboard accessible because of the `tabindex="-1"` in the speaker_box.html include. This PR removes the tabindex when the bio is open, making the links tab accessible again. To test:

- visit the /speakers/ page
- click open a bio
- press tab until you've selected the title
- click the speaker name to close the speaker-info
- tabbing should now take you to the next speaker
- also inspect the `<a>` inside the .speaker-session element to see that it has `tabindex="-1"`

From my testing, simply removing the tabindex entirely has the same affect in terms of keyboard accessibility; it won't let you tab select a link that's hidden. But it's probably good to have tabindex for other reasons I don't know about.
