### PR TITLE
Contrast for pagination focus outlines

### DIFF
--- a/_includes/schedule_nav.html
+++ b/_includes/schedule_nav.html
@@ -2,7 +2,7 @@
   <div class="col-md-6 offset-md-4">
     <nav aria-label="Page navigation">
       <ul class="pagination">
-        <li {% if include.param == "day5" %} class="active page-item" {% endif %}><a href="/workshops" class="page-link">Pre-Conference</a></li>
+        <li {% if include.param == "day0" %} class="active page-item" {% endif %}><a href="/workshops" class="page-link">Pre-Conference</a></li>
         <li {% if include.param == "day1" %} class="active page-item" {% endif %}><a href="/schedule/day-1" class="page-link">Day 1</a></li>
         <li {% if include.param == "day2" %} class="active page-item" {% endif %}><a href="/schedule/day-2" class="page-link">Day 2</a></li>
         <li {% if include.param == "day3" %} class="active page-item" {% endif %}><a href="/schedule/day-3" class="page-link">Day 3</a></li>

--- a/assets/_scss/_pagination.scss
+++ b/assets/_scss/_pagination.scss
@@ -1,0 +1,14 @@
+.page-link {
+
+  &:hover {
+    color: $pagination-hover-color;
+    background-color: $accent-dark;
+    border-color: $pagination-hover-border-color;
+  }
+
+  &:focus {
+    z-index: 4;
+    outline: $pagination-focus-outline;
+    box-shadow: $pagination-focus-box-shadow;
+  }
+}

--- a/assets/_scss/_presentations-workshops.scss
+++ b/assets/_scss/_presentations-workshops.scss
@@ -97,13 +97,17 @@
 
     &:hover,
     &:active {
-      background-color: $accent;
+      background-color: $accent-dark;
     }
 
     &:focus {
-      background-color: $accent;
+      background-color: $white;
       outline: $pagination-focus-outline;
       box-shadow: $pagination-focus-box-shadow;
+    }
+
+    &.active {
+      background-color: $accent;
     }
   }
 }

--- a/assets/_scss/_presentations-workshops.scss
+++ b/assets/_scss/_presentations-workshops.scss
@@ -104,6 +104,7 @@
       background-color: $white;
       outline: $pagination-focus-outline;
       box-shadow: $pagination-focus-box-shadow;
+      z-index: 4;
     }
 
     &.active {

--- a/assets/_scss/_presentations-workshops.scss
+++ b/assets/_scss/_presentations-workshops.scss
@@ -91,6 +91,21 @@
 
 #workshop-sorting-div {
   margin-bottom: 20px;
+
+  & button {
+    border: 1px solid $gray-light;
+
+    &:hover,
+    &:active {
+      background-color: $accent;
+    }
+
+    &:focus {
+      background-color: $accent;
+      outline: $pagination-focus-outline;
+      box-shadow: $pagination-focus-box-shadow;
+    }
+  }
 }
 
 .workshop-well {

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -605,6 +605,9 @@ $pagination-color:                     $link-color !default;
 $pagination-bg:                        $white !default;
 $pagination-border:                    #ddd !default;
 
+$pagination-focus-box-shadow:          0 0 0 .1rem $primary-light !default;
+$pagination-focus-outline:             0 !default;
+
 $pagination-hover-color:               $link-hover-color !default;
 $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -16,6 +16,7 @@
 @import 'clip-circles';
 @import 'testimonials';
 @import 'speakers';
+@import 'pagination';
 @import 'presentations-workshops';
 @import 'schedule';
 @import 'menu';

--- a/workshops/index.html
+++ b/workshops/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Pre-Conference Workshops
+day: day5
 ---
 
 <div class="container">
@@ -9,6 +10,9 @@ title: Pre-Conference Workshops
             <h1>{{ page.title }}</h1>
         </div>
     </div>
+    {% if site.data.conf.have-schedule %}
+        {% include schedule_nav.html param=page.day %}
+    {% endif %}
     <div class="row">
         <div class="col-12 col-sm-12">
             <p>Half-day workshops will start at either 9:00 a.m. or 1:30 p.m.</p>

--- a/workshops/index.html
+++ b/workshops/index.html
@@ -21,10 +21,10 @@ day: day0
     <div class="row" id="workshop-sorting-div">
         <div class="col-12 col-sm-6">
             <div class="btn-group" role="group" aria-label="filter workshop list by time of day">
-                <button type="button" class="btn btn-light sort-workshop-time active" id="all">All</button>
-                <button type="button" class="btn btn-light sort-workshop-time" id="am">AM</button>
-                <button type="button" class="btn btn-light sort-workshop-time" id="pm">PM</button>
-                <!-- <button type="button" class="btn btn-light sort-workshop-time" id="full">Full Day</button> -->
+                <button type="button" class="btn btn-light sort-workshop-time page-link active" id="all">All</button>
+                <button type="button" class="btn btn-light sort-workshop-time page-link" id="am">AM</button>
+                <button type="button" class="btn btn-light sort-workshop-time page-link" id="pm">PM</button>
+                <!-- <button type="button" class="btn btn-light sort-workshop-time page-link" id="full">Full Day</button> -->
             </div>
         </div>
         <!--

--- a/workshops/index.html
+++ b/workshops/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Pre-Conference Workshops
-day: day5
+day: day0
 ---
 
 <div class="container">


### PR DESCRIPTION
Improve the contrast for both the schedule pagination and workshop time pagination outlines. Also adds the schedule pagination to the workshop page for easier transition between the schedule pages. 

To test, navigate through the workshop and schedule pages with keyboard tabbing and test the contrast between the focus outline and the background of that page and button colours.

Resolves #152.