### PR TITLE
apply jumbotron-btn hover styles to focus events

### DIFF
--- a/assets/_scss/_homepage.scss
+++ b/assets/_scss/_homepage.scss
@@ -42,7 +42,7 @@
     color: $jumbotron-btn-color;
     margin: .5em .5em 0 0;
 
-    &:hover {
+    &:hover,&:focus {
       background-color: $jumbotron-btn-color;
       color: $gray-base;
     }


### PR DESCRIPTION
Tab through the buttons that are overlaid on the hero image. The button backgrounds should indicate a focus state that mimics the on hover event. i.e

![Screen Shot 2022-03-24 at 2 01 55 PM](https://user-images.githubusercontent.com/10561752/159981306-7855c81f-7867-4abf-9531-dc8a3a608b5e.png)

Closes #148 