### PR TITLE
Workshop page styling

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -6,6 +6,7 @@
 year: 2022
 hashtag: 'c4l22'
 location: 'Buffalo, New York'
+timezone: 'Eastern'
 search: false
 online-only-conference: false
 # https://research.lib.buffalo.edu/2022code4lib/venues

--- a/_includes/presentation_timeline.html
+++ b/_includes/presentation_timeline.html
@@ -37,7 +37,7 @@
                             {% capture endTime %}{{ eventTime | replace: beginTime, '' }}{% endcapture %}
                             {{ beginTime | date: "%l:%M%p" | strip }} to {{ endTime | date: "%l:%M%p" | strip }}
                         </h2>
-                        <div class="timezone">Eastern Time</div>
+                        <div class="timezone">{{ site.data.conf.timezone }} Time</div>
                     </div>
                 </div>
                 {% if event.groupId %}

--- a/_includes/workshops/card.html
+++ b/_includes/workshops/card.html
@@ -16,11 +16,11 @@
             {% endif %}
             <p>{{ workshop.content | truncatewords: 50 }} <a href="{{ workshop.url }}"><span aria-label="more about {{ workshop.title }}">more</span></a></p>
         </div>
-        <div class="col-12">
+        <div class="col-12 workshop-time">
             <h3 class="h5">Time</h3>
-            <h3 class="h5">{{ post.startTime }} to {{ post.endTime }}
+            <p class="h5">{{ post.startTime }} to {{ post.endTime }}
                 <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
-            </h3>
+            </p>
         </div>
         <!--
         <div class="col-12">

--- a/_includes/workshops/card.html
+++ b/_includes/workshops/card.html
@@ -19,7 +19,7 @@
         <div class="col-12">
             <h3 class="h5">Time</h3>
             <h3 class="h5">{{ post.startTime }} to {{ post.endTime }}
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <!--

--- a/_layouts/presentation.html
+++ b/_layouts/presentation.html
@@ -126,7 +126,7 @@
                 <div class="col-12 col-sm-12 col-md-12 time-slot">
                     <div class="talk-box-detail-icon"><span class="glyphicon glyphicon-time"></span></div>
                     <div class="talk-box-detail-value">{{ page_length }}
-                        <br/><div class="timezone info-box">Eastern Time</div>
+                        <br/><div class="timezone info-box">{{ site.data.conf.timezone }} Time</div>
                     </div>
                 </div>
                 {% elsif page.type == 'poster' %}

--- a/assets/_scss/_presentations-workshops.scss
+++ b/assets/_scss/_presentations-workshops.scss
@@ -120,15 +120,16 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: space-around;
-  margin-top: 10px;
+  margin: 10px 0px;
   padding: 10px 10px 0px;
   width: 300px;
 }
 
-.workshop-well p {
+.workshop-well p,
+.workshop-well ul,
+.workshop-well ol {
   font-size: .9em;
   line-height: 1.3em;
-  word-break: break-all;
 }
 
 .workshop-well a {
@@ -143,6 +144,20 @@
 
 .workshop-well.top-10 {
   background-color: lightgoldenrodyellow;
+}
+
+.workshop-time {
+  font-size: $h5-font-size;
+  font-weight: 700;
+  letter-spacing: .02em;
+  line-height: 1.1;
+
+  & p {
+    margin-top: 1rem;
+    margin-bottom: 0;
+    font-size: 1em;
+    line-height: 1.1em;
+  }
 }
 
 .sched-date {

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -14,7 +14,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>9AM to 5PM
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -33,7 +33,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>{{ site.data.conf.community-gathering.time }}
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -85,7 +85,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>9AM to 5:15PM
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -100,7 +100,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>{{ site.data.conf.game-night.time }}
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -147,7 +147,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>9AM to 5:15PM
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -184,7 +184,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>{{ site.data.conf.karaoke-night.time }}
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -210,7 +210,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>9AM to 12:45PM
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">
@@ -225,7 +225,7 @@ title: Schedule
     <div class="row">
         <div class="col-12 col-md-3 text-right">
             <h3>{{ site.data.conf.trivia-night.time }}
-                <br/><div class="timezone">Eastern Time</div>
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
             </h3>
         </div>
         <div class="col-12 col-md-9 sched-well">


### PR DESCRIPTION
I was recently reviewing the workshops page and wanted to make recommend some small changes to the styling and structure. This PR:

- Adds a variable for the timezone, e.g. "Eastern", which we are using in a few places
- Makes the time on the workshop card a `<p>` instead of a heading for a more logical structure, and adjusts the styling accordingly
- Increases the spacing so that text in the workshop cards isn't too close to the bottom, and so that cards have more spacing at the bottom of the page (between the cards and the footer)
- Changes the word breaking for better readability
- Adds the same styling as paragraphs to lists in workshop descriptions, as currently the font sizes are not consistent
