### PR TITLE
update peri conference state

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -149,20 +149,18 @@ closed-captioning:
 peri:
   day1-am-title: 'Pre-Conference'
   day1-am-desc: 'Workshops'
+  day1-pm-title: 'Newcomer Dinner'
+  day1-pm-desc: 'Dine-Around'
   day2-am-title: 'Conference, Day 1'
-  day2-am-desc: 'Keynote'
+  day2-am-desc: 'Opening Keynote & Talks'
+  day2-pm-title: 'Reception'
+  day2-pm-desc: 'Pearl Street Grill & Brewery'
   day3-am-title: 'Conference, Day 2'
   day3-am-desc: 'Awesome Talks'
   day3-pm-title: 'Game Night'
   day3-pm-desc: 'Board or Card Games'
   day4-am-title: 'Conference, Day 3'
-  day4-am-desc: 'Awesome Talks'
-  day4-pm-title: 'Karaoke Night'
-  day4-pm-desc: 'Join Us'
-  day5-am-title: 'Conference, Day 4'
-  day5-am-desc: 'Awesome Talks'
-  day5-pm-title: 'Trivia Night'
-  day5-pm-desc: 'Bragging Rights'
+  day4-am-desc: 'Closing Keynote & Talks'
 
 ###########
 # Sponsors

--- a/_includes/homepage/peri_conference.html
+++ b/_includes/homepage/peri_conference.html
@@ -30,28 +30,24 @@
     </div>
 
 
-    <div class="col-md-2.5 event-day" data-date="{{ site.data.conf.days[0].date-data }}">
+    <div class="col-md-3 event-day" data-date="{{ site.data.conf.days[0].date-data }}">
         <h2 class="text-center">{{site.data.conf.days[0].date | date: "%b. %d"}}</h2>
-        {% include homepage/event_card.html icon='am' link='/schedule/day-1' title=site.data.conf.peri.day1-am-title description=site.data.conf.peri.day1-am-desc %}
+        {% include homepage/event_card.html icon='am' link='/workshops' title=site.data.conf.peri.day1-am-title description=site.data.conf.peri.day1-am-desc %}
+        {% include homepage/event_card.html icon='pm' link='/general-info/venues/#dinner' title=site.data.conf.peri.day1-pm-title description=site.data.conf.peri.day1-pm-desc %}
     </div>
-    <div class="col-md-2.5 event-day" data-date="{{ site.data.conf.days[1].date-data }}">
+    <div class="col-md-3 event-day" data-date="{{ site.data.conf.days[1].date-data }}">
         <h2 class="text-center">{{site.data.conf.days[1].date | date: "%b. %d"}}</h2>
-        {% include homepage/event_card.html icon='am' link='/schedule/day-2' title=site.data.conf.peri.day2-am-title description=site.data.conf.peri.day2-am-desc %}
-        {% include homepage/event_card.html icon='pm' link='/general-info/social/#game-night' title=site.data.conf.peri.day2-pm-title description=site.data.conf.peri.day2-pm-desc %}
+        {% include homepage/event_card.html icon='am' link='/schedule/day-1' title=site.data.conf.peri.day2-am-title description=site.data.conf.peri.day2-am-desc %}
+        {% include homepage/event_card.html icon='pm' link='/general-info/venues/#reception' title=site.data.conf.peri.day2-pm-title description=site.data.conf.peri.day2-pm-desc %}
     </div>
-    <div class="col-md-2.5 event-day" data-date="{{ site.data.conf.days[2].date-data }}">
+    <div class="col-md-3 event-day" data-date="{{ site.data.conf.days[2].date-data }}">
         <h2 class="text-center">{{site.data.conf.days[2].date | date: "%b. %d"}}</h2>
-        {% include homepage/event_card.html icon='am' link='/schedule/day-3' title=site.data.conf.peri.day3-am-title description=site.data.conf.peri.day3-am-desc %}
-        {% include homepage/event_card.html icon='pm' link='/general-info/social/#karaoke-night' title=site.data.conf.peri.day3-pm-title description=site.data.conf.peri.day3-pm-desc %}
+        {% include homepage/event_card.html icon='am' link='/schedule/day-2' title=site.data.conf.peri.day3-am-title description=site.data.conf.peri.day3-am-desc %}
+        {% include homepage/event_card.html icon='pm' link='/general-info/social/#game-night' title=site.data.conf.peri.day3-pm-title description=site.data.conf.peri.day3-pm-desc %}
     </div>
-    <div class="col-md-2.5 event-day" data-date="{{ site.data.conf.days[3].date-data }}">
+    <div class="col-md-3 event-day" data-date="{{ site.data.conf.days[3].date-data }}">
         <h2 class="text-center">{{site.data.conf.days[3].date | date: "%b. %d"}}</h2>
-        {% include homepage/event_card.html icon='am' link='/schedule/day-4' title=site.data.conf.peri.day4-am-title description=site.data.conf.peri.day4-am-desc %}
-        {% include homepage/event_card.html icon='pm' link='/general-info/social/#trivia-night' title=site.data.conf.peri.day4-pm-title description=site.data.conf.peri.day4-pm-desc %}
-    </div>
-    <div class="col-md-2.5 event-day" data-date="{{ site.data.conf.days[4].date-data }}">
-        <h2 class="text-center">{{site.data.conf.days[4].date | date: "%b. %d"}}</h2>
-        {% include homepage/event_card.html icon='am' link='/workshops' title=site.data.conf.peri.day5-am-title description=site.data.conf.peri.day5-am-desc %}
+        {% include homepage/event_card.html icon='am' link='/schedule/day-3' title=site.data.conf.peri.day4-am-title description=site.data.conf.peri.day4-am-desc %}
     </div>
 
     <div class="col-12 text-center">


### PR DESCRIPTION
To test these changes, you'll need to set the `homepage-display` in `_data/conf.yml` to `peri`.

If any additional commits are required, be sure to check that the homepage-display has been reset to `pre` before merge.

---
Updated homepage card values for this year's events

```
peri:
  day1-am-title: 'Pre-Conference'
  day1-am-desc: 'Workshops'
  day1-pm-title: 'Newcomer Dinner'
  day1-pm-desc: 'Dine-Around'
  day2-am-title: 'Conference, Day 1'
  day2-am-desc: 'Opening Keynote & Talks'
  day2-pm-title: 'Reception'
  day2-pm-desc: 'Pearl Street Grill & Brewery'
  day3-am-title: 'Conference, Day 2'
  day3-am-desc: 'Awesome Talks'
  day3-pm-title: 'Game Night'
  day3-pm-desc: 'Board or Card Games'
  day4-am-title: 'Conference, Day 3'
  day4-am-desc: 'Closing Keynote & Talks'
```

---

`peri_conference.html'
- removed extraneous elements
- updated event includes and site references
- modifying the col-md-3 values to better align the cards for this year's conference