### PR TITLE
adds half-day workshop registration info

### DIFF
--- a/_data/registration.yml
+++ b/_data/registration.yml
@@ -20,15 +20,17 @@ conference:
   limited-capacity: true
 
 workshop-only:
-  # "show" only affects a button on the general-info/attend page
-  show: false
-  undecided: true
+  # "show" only toggles the display of info in the registration bullets on the general-info/attend page
+  show: true
+  # "show-button" only affects a button on the general-info/attend page
+  show-button: false
+  undecided: false
   undecided-text: "Depending on availability, Pre-Conference ONLY registration may open at the beginning of May."
   url:
   # precon-only registration cost may differ from precons with general registration
-  half-day-cost: "$40"
-  full-day-cost: "$80"
-  start-date: 2022-03-01
+  half-day-cost: "$50"
+  full-day-cost:
+  start-date: 2022-05-03
 
 t-shirt-only:
   show: true

--- a/general-info/attend.html
+++ b/general-info/attend.html
@@ -27,7 +27,7 @@ active: Attend Code4Lib
                         </p>
                     {% endif %}
 
-                    {% if site.data.registration.workshop-only.show %}
+                    {% if site.data.registration.workshop-only.show-button %}
                         <h3>Pre-Conference Workshops</h3>
                         <p><a class="btn btn-lg btn-warning" href="{{ site.data.registration.workshop-only.url }}">Pre-Conference Registration</a></p>
                     {% endif %}
@@ -53,7 +53,7 @@ active: Attend Code4Lib
                         <li><span class="font-weight-bold">Pre-Conferences (with main conference registration)</span>: {{ site.data.registration.conference.workshop-half-day-cost }} per half day ({{ site.data.registration.conference.workshop-full-day-cost }} for full day)</li>
 
                         {% if site.data.registration.workshop-only.show %}
-                            <li><span class="font-weight-bold">Pre-Conference Only</span>: {{ site.data.registration.workshop-only.half-day-cost }} per half day ({{ site.data.registration.workshop-only.full-day-cost }} for full day) {%- if site.data.registration.workshop-only.start-date -%}. Opens {{ site.data.registration.workshop-only.start-date | date: "%B %-d" }}.{%- endif -%}</li>
+                            <li><span class="font-weight-bold">Pre-Conference Only</span>: {{ site.data.registration.workshop-only.half-day-cost }} per half day. {% if site.data.registration.workshop-only.full-day-cost != nil %} ({{ site.data.registration.workshop-only.full-day-cost }} for full day).{% endif %} {% if site.data.registration.workshop-only.start-date != nil %} Opens {{ site.data.registration.workshop-only.start-date | date: "%B %-d" }}.{% endif %}</li>
                         {% endif %}
                     {% endif %}
 


### PR DESCRIPTION
This PR:
* add a bullet point for 1/2 day workshop registration on the general-info page
* creates a new boolean in `registration.yml` to toggle the pre-conference registration button on the general-info page

closes #195 