### PR TITLE
reception starts at 6:30pm now

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -342,7 +342,7 @@ reception:
   image: 'pearl-street.jpg'
   image_title: 'Pearl Street Grill & Brewery'
   image_alt: 'Pearl Street Grill & Brewery'
-  times: '6:00PM to 9:00PM'
+  times: '6:30PM to 9:00PM'
   date: '2022-05-24'
 
 self-event:


### PR DESCRIPTION
I got this email from Social Activities:

> Tuesday, May 24th,  6:30pm - 9pm
> Reception : Pearl Street Grill & Brewery - About the brewery
> 76 Pearl Street Buffalo, NY 14202 (Seneca Station Light Metro Rail - free above ground)

To test:

- view /schedule/ specifically under Tuesday
- visit /general-info/venues/#reception

I _think_ those are the only two places the time is shown.
