### PR TITLE
removes withdrawn speaker, pascal-belouin

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -378,18 +378,6 @@
   image_alt:
 
 
-- id: pascal-belouin
-  name: Pascal Belouin
-  last: Belouin
-  pronouns: he
-  institution: Max Planck Institute for the History of Science
-  title:
-  bio: "Pascal Belouin is a Digital Humanities researcher at the Max Planck Institute for the History of Science, where he supports historians of science in applying digital methods to their research, and explores various DH research topics such as, among other things, knowledge modelling, distant reading, network analysis, and data visualisation."
-  keynote: FALSE
-  image_src:
-  image_alt:
-
-
 - id: naomi-dushay
   name: Naomi Dushay
   last: Dushay

--- a/_posts/2022-01-01-Building-a-Central-Knowledge-Graph-for-Digital-Humanities-Research-Data.md
+++ b/_posts/2022-01-01-Building-a-Central-Knowledge-Graph-for-Digital-Humanities-Research-Data.md
@@ -2,7 +2,7 @@
 layout: presentation
 type: talk 
 startTime: 2022-05-25T09:45
-speakers-text: Kim Pham, Pascal Belouin
+speakers-text: Kim Pham
 categories: talks
 day: 2
 group: 4
@@ -10,7 +10,6 @@ spot: 3
 time: 9:45 AM
 speakers:
 - kim-pham
-- pascal-belouin
 length: 15
 slugTitle: building-a-central-knowledge-graph-for-digital-humanities-research-data
 location: Auditorium 2120 A&B


### PR DESCRIPTION
This PR:
- removes pascal-belouin speaker object from `speakers.yml`
- removes pascal-belouin from `_posts` file

closes #205 