### PR TITLE
add Hayes Hall and South Campus links to workshop venues

### DIFF
--- a/general-info/venues/workshops.html
+++ b/general-info/venues/workshops.html
@@ -8,7 +8,7 @@
         {%- endcomment -%}
 
         <p>
-            All Pre-Conference workshops will be held {{ site.data.conf.days[0].weekday }}, {{ site.data.conf.days[0].date-data | date: "%B %-d, %Y" }}, in Hayes Hall at the University at Buffalo's South Campus (3435 Main St, Buffalo, NY 14214). This is an approximately 15-minute commute from the JSMBS building, via the Metro Rail and a short amount of walking. The station name for JSMBS is Allen-Medical Campus, and the station name for UB's South Campus is University Station. The Metro Rail is one line.
+            All Pre-Conference workshops will be held {{ site.data.conf.days[0].weekday }}, {{ site.data.conf.days[0].date-data | date: "%B %-d, %Y" }}, in <a href="https://www.buffalo.edu/administrative-services/managing-facilities/planning-designing-and-construction/building-profiles/profile-host-page.host.html/content/shared/university/page-content/facilities/hayes.detail.html" target="_blank">Hayes Hall</a> at the University at Buffalo's <a href="https://www.buffalo.edu/home/visiting-ub.to-south-campus.html#directions" target="_blank">South Campus</a> (3435 Main St, Buffalo, NY 14214). This is an approximately 15-minute commute from the JSMBS building, via the Metro Rail and a short amount of walking. The station name for JSMBS is Allen-Medical Campus, and the station name for UB's South Campus is University Station. The Metro Rail is one line.
         </p>
     </div>
 </section>


### PR DESCRIPTION
Links are placed on `/general-info/venues/`

<img width="616" alt="Screen Shot 2022-05-12 at 9 19 25 PM" src="https://user-images.githubusercontent.com/10561752/168192674-26fb0295-2b17-4cfd-a899-d188bb83a034.png">

Closes #220 