### PR TITLE
move tours & simulation workshop to Wednesday

### DIFF
--- a/schedule/index.html
+++ b/schedule/index.html
@@ -51,48 +51,6 @@ title: Schedule
     </div>
     {% endif %}
 
-    {% if site.data.conf.simulation.show %}
-    <div class="row">
-        <div class="col-12 col-md-3 text-right">
-            <h3>{{ site.data.conf.simulation.time }}
-                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
-            </h3>
-        </div>
-        <div class="col-12 col-md-9 sched-well">
-            <h4>Simulation Workshop</h4>
-            <p>
-                See the <a href="/general-info/social/#simulation">Social Activities</a> page for more details.
-            </p>
-            {% if site.data.conf.simulation.sign-up-url != '' %}
-                <p>
-                    <a class="btn ct-btn-light" href="{{ site.data.conf.simulation.sign-up-url }}">{{ site.data.conf.simulation.sign-up-button-text }}</a>
-                </p>
-            {% endif %}
-        </div>
-    </div>
-    {% endif %}
-
-    {% if site.data.conf.tours.show %}
-    <div class="row">
-        <div class="col-12 col-md-3 text-right">
-            <h3>{{ site.data.conf.tours.time }}
-                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
-            </h3>
-        </div>
-        <div class="col-12 col-md-9 sched-well">
-            <h4>Tours</h4>
-            <p>
-                See the <a href="/general-info/social/#tours">Social Activities</a> page for more details.
-            </p>
-            {% if site.data.conf.tours.sign-up-url != '' %}
-                <p>
-                    <a class="btn ct-btn-light" href="{{ site.data.conf.tours.sign-up-url }}">{{ site.data.conf.tours.sign-up-button-text }}</a>
-                </p>
-            {% endif %}
-        </div>
-    </div>
-    {% endif %}
-
     {% if site.data.conf.newcomer-dinner.show %}
     <div class="row">
         <div class="col-12 col-md-3 text-right">
@@ -176,29 +134,72 @@ title: Schedule
                 Talks have been selected by the community.
             </p>
         </div>
-        {% if site.data.conf.game-night.show %}
-        <div class="row">
-            <div class="col-12 col-md-3 text-right">
-                <h3>{{ site.data.conf.game-night.time }}
-                    <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
-                </h3>
-            </div>
-            <div class="col-12 col-md-9 sched-well">
-                <h4>
-                    <a href="/general-info/social/#game-night">Game Night</a>
-                </h4>
-                <p>
-                {{ site.data.conf.game-night.description }}
-                </p>
-                {% if site.data.conf.game-night.sign-up-url != '' %}
-                    <p>
-                        <a class="btn ct-btn-light" href="{{ site.data.conf.game-night.sign-up-url }}">{{ site.data.conf.game-night.sign-up-button-text }}</a>
-                    </p>
-                {% endif %}
-            </div>
-        </div>
-        {% endif %}
     </div>
+
+    {% if site.data.conf.simulation.show %}
+    <div class="row">
+        <div class="col-12 col-md-3 text-right">
+            <h3>{{ site.data.conf.simulation.time }}
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
+            </h3>
+        </div>
+        <div class="col-12 col-md-9 sched-well">
+            <h4>Simulation Workshop</h4>
+            <p>
+                See the <a href="/general-info/social/#simulation">Social Activities</a> page for more details.
+            </p>
+            {% if site.data.conf.simulation.sign-up-url != '' %}
+                <p>
+                    <a class="btn ct-btn-light" href="{{ site.data.conf.simulation.sign-up-url }}">{{ site.data.conf.simulation.sign-up-button-text }}</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if site.data.conf.tours.show %}
+    <div class="row">
+        <div class="col-12 col-md-3 text-right">
+            <h3>{{ site.data.conf.tours.time }}
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
+            </h3>
+        </div>
+        <div class="col-12 col-md-9 sched-well">
+            <h4>Tours</h4>
+            <p>
+                See the <a href="/general-info/social/#tours">Social Activities</a> page for more details.
+            </p>
+            {% if site.data.conf.tours.sign-up-url != '' %}
+                <p>
+                    <a class="btn ct-btn-light" href="{{ site.data.conf.tours.sign-up-url }}">{{ site.data.conf.tours.sign-up-button-text }}</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if site.data.conf.game-night.show %}
+    <div class="row">
+        <div class="col-12 col-md-3 text-right">
+            <h3>{{ site.data.conf.game-night.time }}
+                <br/><div class="timezone">{{ site.data.conf.timezone }} Time</div>
+            </h3>
+        </div>
+        <div class="col-12 col-md-9 sched-well">
+            <h4>
+                <a href="/general-info/social/#game-night">Game Night</a>
+            </h4>
+            <p>
+            {{ site.data.conf.game-night.description }}
+            </p>
+            {% if site.data.conf.game-night.sign-up-url != '' %}
+                <p>
+                    <a class="btn ct-btn-light" href="{{ site.data.conf.game-night.sign-up-url }}">{{ site.data.conf.game-night.sign-up-button-text }}</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
 
     {% if site.data.conf.libtech-women.show %}
     <div class="row">


### PR DESCRIPTION
This closes #222. The issue only mentions the tours but I see from [the Simulation Workshop's details](https://2022.code4lib.org/general-info/social/#simulation) that it was also meant to be on Wednesday.

To test:

- visit /schedule/ and confirm that the Tours and Simulation events appear under Wednesday

