### PR TITLE
turn on peri-conference display

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -124,7 +124,7 @@ anonymous-form: 'https://css4csv.clir.org/anonymous-incident-report-form/'
 # - post:   for after the conference is over (TODO: we never made this template!)
 #
 ####################
-homepage-display: pre
+homepage-display: peri
 
 livestream:
   show: false

--- a/assets/_scss/_homepage-events.scss
+++ b/assets/_scss/_homepage-events.scss
@@ -77,7 +77,7 @@
     }
 
     p {
-      color: #a1a1a1;
+      color: #575757;
       margin: 0;
       line-height: initial;
     }


### PR DESCRIPTION
Scheduled PR to turn on the peri-conference homepage template. I'd appreciate if someone else could review this but **don't merge** because we want the scheduler to do that. I'm setting it to go live on Sunday so a day before the conference.

To test:
- view the home page
- test the links in the cards
