### PR TITLE
UPDATE: reschedule group 1 sessions

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -72,16 +72,16 @@
   link:
 
 # lightning
-- timeImg: 3.00.png
+- timeImg: 3.20.png
   title: Lightning Talks 1
   day1: true
-  time: 15:00-16:15
+  time: 15:20-16:15
   link:
 
-- timeImg: 10.15.png
+- timeImg: 10.30.png
   title: Lightning Talks 2
   day2: true
-  time: 10:15-11:00
+  time: 10:30-11:00
   link:
 
 - timeImg: 10.15.png
@@ -189,3 +189,15 @@
   day3: true
   groupId: 8
   time: 11:45-12:30
+
+- timeImg: 3.00.png
+  title: Rescheduled, Group 1&#58; 20 minutes (2 talks)
+  day1: true
+  groupId: 100
+  time: 15:00 - 15:20
+
+- timeImg: 10.15.png
+  title: Rescheduled, Group 1&#58; 15 minutes (1 talk)
+  day2: true
+  groupId: 101
+  time: 10:15 - 10:30

--- a/_posts/2022-01-01-Automation-as-a-pathway-toward-slow-librarianship.md
+++ b/_posts/2022-01-01-Automation-as-a-pathway-toward-slow-librarianship.md
@@ -1,13 +1,13 @@
 ---
 layout: presentation
 type: talk 
-startTime: 2022-05-24T11:45
+startTime: 2022-05-24T15:10
 speakers-text: Wesley Teal
 categories: talks
 day: 1
-group: 1
-spot: 7
-time: 11:45 AM
+group: 100
+spot: 2
+time: 3:10 PM
 speakers:
 - wesley-teal
 length: 10

--- a/_posts/2022-01-01-From-Raw-Data-to-Leaflet-Maps.md
+++ b/_posts/2022-01-01-From-Raw-Data-to-Leaflet-Maps.md
@@ -1,13 +1,13 @@
 ---
 layout: presentation
 type: talk 
-startTime: 2022-05-24T11:20
-speakers-text: Dr. Patrick Murray-John, William Reed Quinn
+startTime: 2022-05-25T10:15
+speakers-text: William Reed Quinn
 categories: talks
-day: 1
-group: 1
-spot: 5
-time: 11:20 AM
+day: 2
+group: 101
+spot: 1
+time: 10:15 AM
 speakers:
 - william-reed-quinn
 length: 15

--- a/_posts/2022-01-01-Unlikely-Allies-of-Textbook-Affordability-Python-Bookstore-Data-and-a-Discovery-API.md
+++ b/_posts/2022-01-01-Unlikely-Allies-of-Textbook-Affordability-Python-Bookstore-Data-and-a-Discovery-API.md
@@ -1,13 +1,13 @@
 ---
 layout: presentation
 type: talk 
-startTime: 2022-05-24T11:35
+startTime: 2022-05-24T15:00
 speakers-text: Julia Caffrey-Hill
 categories: talks
 day: 1
-group: 1
-spot: 6
-time: 11:35 AM
+group: 100
+spot: 1
+time: 3:00 PM
 speakers:
 - julia-caffrey-hill
 length: 10


### PR DESCRIPTION
Updates the conference schedule to show rescheduled Group 1 presentations.

---

**Day 1 from 3:00 - 3:20, followed by lightening talks:**

3:00 - Unlikely Allies of Textbook Affordability: Python, Bookstore Data, and a Discovery API
Julia Caffrey-Hill

3:10 - Automation as a pathway toward slow librarianship
Wesley Teal

---

**Day 2 from 10:15 - 10:30, followed by lightening talks:**

10:15 - From Raw Data to Leaflet Maps
William Reed Quinn
