### PR TITLE
UPDATE: switch site into post-conference mode

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -124,15 +124,15 @@ anonymous-form: 'https://css4csv.clir.org/anonymous-incident-report-form/'
 # - post:   for after the conference is over (TODO: we never made this template!)
 #
 ####################
-homepage-display: peri
+homepage-display: post
 
 livestream:
-  show: true
+  show: false
   button-label: 'Join Livestream'
   url: 'https://www.youtube.com/c/Code4Lib'
 
 slides:
-  show: true
+  show: false
   url: 'https://osf.io/meetings/c4l22'
   contact: ''
   email: ''
@@ -141,8 +141,7 @@ slide-template:
   url: '/assets/C4L2021-template.pptx'
 
 closed-captioning:
-  url: https://2020archive.1capapp.com/event/code4lib/
-  show: true
+  url:
 
 # Peri display descriptions and titles
 peri:

--- a/_data/post-conference.yml
+++ b/_data/post-conference.yml
@@ -1,0 +1,23 @@
+# we will generally want to highlight: the youtube playlist of recordings, the
+# slides repo, post-conference survey, and proposals for the coming year
+
+# @TODO unique icons
+cards:
+    - header: 'Session Recordings'
+      icon: video
+      subtitle: 'View on YouTube'
+      link: 'https://www.youtube.com/playlist?list=PLw-ls5JXzeNYN8xk_PLZvaXF0JqhQXrf6'
+      description:
+          View the full recordings of the conference from the livestream!
+    - header: 'Session Slides'
+      icon: slides
+      subtitle: ''
+      link: https://osf.io/meetings/c4l22/
+      description:
+          View the <a href="https://osf.io/meetings/c4l22/">Open Science Foundation repository</a> with slides and materials from the presentations.
+    - header: 'What Comes Next?'
+      icon: future
+      subtitle: 'Code4Lib 2023'
+      link: https://forms.gle/Y462yDjCPk9B8PyWA
+      description:
+          Attendees, fill out <a href="https://forms.gle/Y462yDjCPk9B8PyWA">the post-conference survey</a>!

--- a/general-info/venues/accommodations.html
+++ b/general-info/venues/accommodations.html
@@ -20,7 +20,7 @@
         <h3>Live Captioning</h3>
         <p>
             During the general conference, Code4Lib {{site.data.conf.year}} will feature live captioning.
-            {% if site.data.conf.closed-captioning.show %}
+            {% if site.data.conf.closed-captioning.url != nil %}
                 Attendees, both local and remote, may view the text stream at:
                 <a href="{{ site.data.conf.closed-captioning.url }}">{{ site.data.conf.closed-captioning.url }}</a>.
             {% endif %}


### PR DESCRIPTION
This PR:
- enables **post** mode of the conference site
- updates homepage card links for 2022 (i.e. recordings, slides, survey)
- removes peri-conference buttons from jumbotron

To test:
- ensure that each post-conference card directs to the 2022 session recordings, OSF meeting site, and post-conference survey
<img width="974" alt="Screen Shot 2022-05-30 at 6 11 34 PM" src="https://user-images.githubusercontent.com/10561752/171063666-785688b6-12dc-4185-937b-7ae67d0d5052.png">

 